### PR TITLE
Add D+ keys and a few URNs

### DIFF
--- a/episodes/season_01.yml
+++ b/episodes/season_01.yml
@@ -5,6 +5,7 @@ episodes:
   episode: 1
   description: Homer decides to gamble on a "hunch" at the dog track when his annual
     Christmas bonus is canceled.
+  disneyplus_id:
   simpsonsworld_id: 273376835817
   good: false
   characters:
@@ -14,6 +15,7 @@ episodes:
   episode: 2
   description: Bart is believed to be a genius after he switches I.Q. tests with brainy
     Martin Prince.
+  disneyplus_id:
   simpsonsworld_id: 283744835990
   good: false
   characters:
@@ -23,6 +25,7 @@ episodes:
   episode: 3
   description: Fired from his job at the Nuclear Power Plant, Homer decides to embark
     on a campaign to make all of Springfield safer.
+  disneyplus_id:
   simpsonsworld_id: 273381443699
   good: false
   characters:
@@ -33,6 +36,7 @@ episodes:
   description: After attending the annual company picnic, Homer becomes jealous of
     fellow employees with 'normal' families.  He decides to enlist the aid of psychologist
     Marvin Monroe to treat his wife and children.
+  disneyplus_id:
   simpsonsworld_id: 273392195780
   good: true
   characters:
@@ -43,6 +47,7 @@ episodes:
   episode: 5
   description: Grandpa Simpson aids Bart in his war against a school bully and his
     gang.
+  disneyplus_id:
   simpsonsworld_id: 300934723994
   good: false
   characters:
@@ -52,6 +57,7 @@ episodes:
   season: 1
   episode: 6
   description: Lisa befriends a saxophone player when she develops a case of the blues.
+  disneyplus_id:
   simpsonsworld_id: 273391683535
   good: false
   characters:
@@ -62,6 +68,7 @@ episodes:
   episode: 7
   description: Homer is mistaken for Bigfoot when he takes his family on a trip into
     the wilderness in their new camper.
+  disneyplus_id:
   simpsonsworld_id: 273396803837
   good: false
   characters:
@@ -72,6 +79,7 @@ episodes:
   episode: 8
   description: Bart attempts to impress his new friends by vandalizing a statue of
     the town's founding father, Jebediah Springfield.
+  disneyplus_id:
   simpsonsworld_id: 305663555641
   good: true
   characters:
@@ -82,6 +90,7 @@ episodes:
   episode: 9
   description: Marge contemplates having an affair with a local womanizer after Homer
     selfishly buys her a bowling ball for her birthday.
+  disneyplus_id:
   simpsonsworld_id: 280384579592
   good: false
   characters:
@@ -92,6 +101,7 @@ episodes:
   description: Bart photographs Homer with belly-dancer Princess Kashmir.  Marge will
     only forgive her husband when he proves to Bart that all women are not merely
     sexual objects.
+  disneyplus_id:
   simpsonsworld_id: 275197507879
   good: false
   characters:
@@ -102,6 +112,7 @@ episodes:
   episode: 11
   description: To Homer's delight, Bart is sent to France for the summer as part of
     a student exchange program.
+  disneyplus_id:
   simpsonsworld_id: 306382403766
   good: true
   characters:
@@ -111,6 +122,7 @@ episodes:
   episode: 12
   description: When Homer positively identifies Krusty the Clown as an armed robber,
     Bart attempts to clear his idol's name.
+  disneyplus_id:
   simpsonsworld_id: 288019523914
   good: true
   characters:
@@ -121,6 +133,7 @@ episodes:
   episode: 13
   description: Marge and Homer unwittingly leave their children in the care of a villainous
     babysitter when they attempt to rekindle their marriage.
+  disneyplus_id:
   simpsonsworld_id: 274504771647
   good: false
   characters:

--- a/episodes/season_01.yml
+++ b/episodes/season_01.yml
@@ -5,7 +5,7 @@ episodes:
   episode: 1
   description: Homer decides to gamble on a "hunch" at the dog track when his annual
     Christmas bonus is canceled.
-  disneyplus_id:
+  disneyplus_id: 79529cd0-f1cf-4eec-8b1d-ea1e1b76043b
   simpsonsworld_id: 273376835817
   good: false
   characters:
@@ -15,7 +15,7 @@ episodes:
   episode: 2
   description: Bart is believed to be a genius after he switches I.Q. tests with brainy
     Martin Prince.
-  disneyplus_id:
+  disneyplus_id: 250ca502-751e-4b37-a465-f8b518d76ced
   simpsonsworld_id: 283744835990
   good: false
   characters:
@@ -25,7 +25,7 @@ episodes:
   episode: 3
   description: Fired from his job at the Nuclear Power Plant, Homer decides to embark
     on a campaign to make all of Springfield safer.
-  disneyplus_id:
+  disneyplus_id: 0e8e7f27-0ab2-495f-8254-d99d3c53ce4f
   simpsonsworld_id: 273381443699
   good: false
   characters:
@@ -36,7 +36,7 @@ episodes:
   description: After attending the annual company picnic, Homer becomes jealous of
     fellow employees with 'normal' families.  He decides to enlist the aid of psychologist
     Marvin Monroe to treat his wife and children.
-  disneyplus_id:
+  disneyplus_id: 5e837a36-5db0-451c-82d3-0cca1490f784
   simpsonsworld_id: 273392195780
   good: true
   characters:

--- a/episodes/season_02.yml
+++ b/episodes/season_02.yml
@@ -4,6 +4,7 @@ episodes:
   season: 2
   episode: 1
   description: Bart must pass a critical history test or he will be held back a grade.
+  disneyplus_id:
   simpsonsworld_id: 260539459671
   good: false
   characters:
@@ -13,6 +14,7 @@ episodes:
   episode: 2
   description: Homer's life changes dramatically when he purchases a miracle hair
     growth formula.
+  disneyplus_id:
   simpsonsworld_id: 260539971564
   good: true
   characters:
@@ -22,6 +24,7 @@ episodes:
   episode: 3
   description: The Simpsons tell three bloodcurdling tales of horror on Halloween
     night.
+  disneyplus_id:
   simpsonsworld_id: 260538435884
   good: true
   characters:
@@ -31,6 +34,7 @@ episodes:
   episode: 4
   description: Homer supports Mr. Burns in his bid for governor, but Marge remains
     loyal to Burns's political opposition.
+  disneyplus_id:
   simpsonsworld_id: 260537411822
   good: true
   characters:
@@ -41,6 +45,7 @@ episodes:
   season: 2
   episode: 5
   description: Homer becomes the official mascot for a major league baseball team.
+  disneyplus_id:
   simpsonsworld_id: 260538435888
   good: true
   characters:
@@ -50,6 +55,7 @@ episodes:
   episode: 6
   description: Homer and Ned Flanders pressure their sons to win a miniature golf
     championship.
+  disneyplus_id:
   simpsonsworld_id: 260539459670
   good: true
   characters:
@@ -61,6 +67,7 @@ episodes:
   episode: 7
   description: Bart learns the true meaning of Thanksgiving when he runs away from
     home after having an argument with Lisa.
+  disneyplus_id:
   simpsonsworld_id: 260539459701
   good: false
   characters:
@@ -71,6 +78,7 @@ episodes:
   episode: 8
   description: Bart is determined to leap a gorge on his skateboard after witnessing
     the death defying stunts of a real daredevil.
+  disneyplus_id:
   simpsonsworld_id: 260539459702
   good: true
   characters:
@@ -80,6 +88,7 @@ episodes:
   episode: 9
   description: Marge initiates a protest movement against gratuitous violence on television
     when Maggie begins acting aggressively after viewing Itchy and Scratchy cartoons.
+  disneyplus_id:
   simpsonsworld_id: 1094123075920
   good: true
   characters:
@@ -89,6 +98,7 @@ episodes:
   episode: 10
   description: When Mr. Burns hits Bart with his car, Homer is enticed by a disreputable
     lawyer to sue him.
+  disneyplus_id:
   simpsonsworld_id: 260550723760
   good: true
   characters:
@@ -100,6 +110,7 @@ episodes:
   episode: 11
   description: Homer believes he has only twenty-four hours to live after he eats
     an improperly prepared blowfish.
+  disneyplus_id:
   simpsonsworld_id: 260548675839
   good: true
   characters:
@@ -109,6 +120,7 @@ episodes:
   episode: 12
   description: Marge recounts to her children how she and Homer first met and fell
     in love.
+  disneyplus_id:
   simpsonsworld_id: 260549187876
   good: false
   characters:
@@ -119,6 +131,7 @@ episodes:
   episode: 13
   description: Lisa disapproves when Homer has cable television installed illegally
     into their home.
+  disneyplus_id:
   simpsonsworld_id: 260820547692
   good: true
   characters:
@@ -129,6 +142,7 @@ episodes:
   episode: 14
   description: Homer arranges a date between Principal Skinner and Marge's sister,
     Selma.
+  disneyplus_id:
   simpsonsworld_id: 263496771968
   good: true
   characters:
@@ -140,6 +154,7 @@ episodes:
   episode: 15
   description: Homer locates his long lost half brother Herb and discovers that he
     is rich.
+  disneyplus_id:
   simpsonsworld_id: 1094123587812
   good: false
   characters:
@@ -149,6 +164,7 @@ episodes:
   episode: 16
   description: Bart must help train Santa's Little Helper to pass an obedience course
     or Homer will give the dog away.
+  disneyplus_id:
   simpsonsworld_id: 272034883946
   good: true
   characters:
@@ -158,6 +174,7 @@ episodes:
   season: 2
   episode: 17
   description: Grampa Simpson falls in love... and inherits a fortune.
+  disneyplus_id:
   simpsonsworld_id: 263504963955
   good: false
   characters:
@@ -168,6 +185,7 @@ episodes:
   description: Marge renews her interest in becoming an artist after Homer finds an
     old painting of Ringo Starr in the attic.  Mr. Burns commissions Marge to paint
     a portrait of him.
+  disneyplus_id:
   simpsonsworld_id: 1094212163883
   good: true
   characters:
@@ -178,6 +196,7 @@ episodes:
   episode: 19
   description: Lisa develops a crush on her substitute teacher, Mr. Bergstrom.  Bergstrom
     tells Homer he must learn to act as a positive role model for his daughter.
+  disneyplus_id:
   simpsonsworld_id: 288011331912
   good: true
   characters:
@@ -188,6 +207,7 @@ episodes:
   description: Marge insists Homer accompany her for a weekend of marriage counseling
     at a wooded retreat, but Homer takes advantage of the location to attempt to catch
     a legendary catfish.
+  disneyplus_id:
   simpsonsworld_id: 272040003661
   good: true
   characters:
@@ -198,6 +218,7 @@ episodes:
   episode: 21
   description: Bart and his friends pool their money to purchase the first issue of
     "Radioactive Man" comics, but then cannot decide who gets to keep it.
+  disneyplus_id:
   simpsonsworld_id: 310368835964
   good: true
   characters:
@@ -209,6 +230,7 @@ episodes:
   episode: 22
   description: Homer expects a generous gift in return when he donates Bart's blood
     to an ailing Mr. Burns.
+  disneyplus_id:
   simpsonsworld_id: 272041539932
   good: true
   characters:

--- a/episodes/season_03.yml
+++ b/episodes/season_03.yml
@@ -6,6 +6,7 @@ episodes:
   description: Homer is institutionalized after Bart fills out his sanity test.  A
     man who thinks he is Michael Jackson helps Bart write a song for Lisa when he
     forgets her birthday.
+  disneyplus_id:
   simpsonsworld_id: 272234051980
   good: false
   characters:
@@ -15,6 +16,7 @@ episodes:
   episode: 2
   description: The Simpsons travel to the Nation's Capitol when Lisa becomes a semifinalist
     in an essay contest on patriotism.
+  disneyplus_id:
   simpsonsworld_id: 275196995796
   good: true
   characters:
@@ -24,6 +26,7 @@ episodes:
   episode: 3
   description: Ned Flanders opens a store for left-handed people and Homer is overjoyed
     when it performs poorly.
+  disneyplus_id:
   simpsonsworld_id: 272051267562
   good: true
   characters:
@@ -34,6 +37,7 @@ episodes:
   episode: 4
   description: Bart fraternizes with a gang of mobsters and becomes the prime suspect
     when Principal Skinner mysteriously disappears.
+  disneyplus_id:
   simpsonsworld_id: 288015427922
   good: true
   characters:
@@ -44,6 +48,7 @@ episodes:
   episode: 5
   description: Homer becomes a hero when he averts a catastrophe at the power plant,
     but what is perceived as his skill of being a quick thinker is actually dumb luck.
+  disneyplus_id:
   simpsonsworld_id: 256843843704
   good: true
   characters:
@@ -53,6 +58,7 @@ episodes:
   episode: 6
   description: Bart and Lisa scheme to reunite Krusty the Clown with his father, Rabbi
     Krustofsky, who disowned him for not carrying on the family tradition.
+  disneyplus_id:
   simpsonsworld_id: 256874051703
   good: true
   characters:
@@ -64,6 +70,7 @@ episodes:
   episode: 7
   description: The Simpsons eat too much candy on Halloween and experience nightmarish
     tales of horror while they sleep.
+  disneyplus_id:
   simpsonsworld_id: 272054339616
   good: true
   characters:
@@ -73,6 +80,7 @@ episodes:
   episode: 8
   description: Homer realizes that he never shows Lisa the attention she deserves
     and buys her a pony.
+  disneyplus_id:
   simpsonsworld_id: 310374467809
   good: false
   characters:
@@ -83,6 +91,7 @@ episodes:
   episode: 9
   description: Realizing he has not been a good father to Bart, Homer aids his son
     in building a soap box racer.
+  disneyplus_id:
   simpsonsworld_id: 256898115598
   good: true
   characters:
@@ -93,6 +102,7 @@ episodes:
   episode: 10
   description: Homer gives Moe the recipe for a unique alcoholic drink, and when it
     turns into a sensation, Moe takes credit, and the profits, from its success.
+  disneyplus_id:
   simpsonsworld_id: 305663555961
   good: true
   characters:
@@ -103,6 +113,7 @@ episodes:
   episode: 11
   description: Homer is fired from his job when a German firm buys the power plant
     from Mr. Burns.
+  disneyplus_id:
   simpsonsworld_id: 310380099512
   good: false
   characters:
@@ -112,6 +123,7 @@ episodes:
   episode: 12
   description: When Marge believes she may be pregnant, Homer recounts how Bart was
     born.
+  disneyplus_id:
   simpsonsworld_id: 299618371603
   good: false
   characters:
@@ -123,6 +135,7 @@ episodes:
   description: Using his Superstar Celebrity microphone, Bart tricks all of Springfield
     into believing that a child has fallen down a well.  But when he falls into the
     same well, Bart cannot get anyone to save him.
+  disneyplus_id:
   simpsonsworld_id: 272052803895
   good: true
   characters:
@@ -132,6 +145,7 @@ episodes:
   episode: 14
   description: Lisa accurately predicts the winners of sporting events that Homer
     gambles on so she can be closer to her father.
+  disneyplus_id:
   simpsonsworld_id: 273404483565
   good: true
   characters:
@@ -142,6 +156,7 @@ episodes:
   episode: 15
   description: When Marge reaches the breaking point, she leaves for a much needed
     vacation, leaving the rest of the family to realize how much she does for them.
+  disneyplus_id:
   simpsonsworld_id: 272224835795
   good: false
   characters:
@@ -152,6 +167,7 @@ episodes:
   episode: 16
   description: When Bart discovers that his divorced teacher, Mrs. Krabappel, has
     placed a "personals" ad in the local newspaper, he decides to create fake correspondence.
+  disneyplus_id:
   simpsonsworld_id: 272228931984
   good: true
   characters:
@@ -163,6 +179,7 @@ episodes:
   description: Mr. Burns bets one million dollars that his power plant's softball
     team will win the championship, then hires professional baseball players to be
     members of the team.
+  disneyplus_id:
   simpsonsworld_id: 310380099768
   good: true
   characters:
@@ -173,6 +190,7 @@ episodes:
   episode: 18
   description: Bart finds new respect for the law and Lisa hangs out with the wrong
     crowd after they both take career aptitude tests.
+  disneyplus_id:
   simpsonsworld_id: 263513155607
   good: true
   characters:
@@ -183,6 +201,7 @@ episodes:
   episode: 19
   description: The Simpsons must choose between frills and their dog when Santa's
     Little Helper needs an expensive operation to save its life.
+  disneyplus_id:
   simpsonsworld_id: 274404419620
   good: true
   characters:
@@ -192,6 +211,7 @@ episodes:
   season: 3
   episode: 20
   description: Homer becomes the manager of a beautiful Country Western singer.
+  disneyplus_id:
   simpsonsworld_id: 272215619762
   good: true
   characters:
@@ -201,6 +221,7 @@ episodes:
   episode: 21
   description: To Bart's horror, Selma announces that her husband-to-be is none other
     than Sideshow Bob.
+  disneyplus_id:
   simpsonsworld_id: 272221251812
   good: true
   characters:
@@ -211,6 +232,7 @@ episodes:
   episode: 22
   description: Bart attends a Spinal Tap concert.  Otto loses his job driving the
     school bus and moves in with the Simpsons.
+  disneyplus_id:
   simpsonsworld_id: 279103043694
   good: true
   characters:
@@ -221,6 +243,7 @@ episodes:
   episode: 23
   description: Bart becomes jealous when Milhouse falls for a girl who transferred
     to their school.
+  disneyplus_id:
   simpsonsworld_id: 280393283967
   good: true
   characters:
@@ -231,6 +254,7 @@ episodes:
   episode: 24
   description: 'Herb Powell asks his brother Homer to let him borrow $2000 to develop
     a new invention: a translator of baby gibberish.'
+  disneyplus_id:
   simpsonsworld_id: 279098435798
   good: false
   characters:

--- a/episodes/season_04.yml
+++ b/episodes/season_04.yml
@@ -5,6 +5,7 @@ episodes:
   episode: 1
   description: Bart and Lisa are horrified when their summer at Kamp Krusty turns
     into a nightmare.
+  disneyplus_id:
   simpsonsworld_id: 279133251579
   good: true
   characters:
@@ -15,6 +16,7 @@ episodes:
   episode: 2
   description: When Marge lands the role of Blanche in a local production of "A Streetcar
     Named Desire," Homer cannot hide his disinterest.
+  disneyplus_id:
   simpsonsworld_id: 273537603751
   good: true
   characters:
@@ -23,6 +25,7 @@ episodes:
   episode: 3
   description: Homer creates his own religion as a means of escaping church services
     on Sundays.
+  disneyplus_id:
   simpsonsworld_id: 279137859827
   good: true
   characters:
@@ -31,6 +34,7 @@ episodes:
   season: 4
   episode: 4
   description: Homer enters Lisa in a beauty pageant when her self-esteem plummets.
+  disneyplus_id:
   simpsonsworld_id: 273537603930
   good: true
   characters:
@@ -41,6 +45,7 @@ episodes:
   episode: 5
   description: During a Halloween party, the Simpsons tell three horrifying tales
     of the macabre.
+  disneyplus_id:
   simpsonsworld_id: 305668675610
   good: true
   characters:
@@ -50,6 +55,7 @@ episodes:
   episode: 6
   description: Homer forbids his son from seeing a new movie about his favorite cartoon
     heroes as punishment for misbehaving.
+  disneyplus_id:
   simpsonsworld_id: 278803011830
   good: true
   characters:
@@ -60,6 +66,7 @@ episodes:
   episode: 7
   description: When the foundation to the Simpsons' house is need of an expensive
     repair, Marge takes a position at the power plant where Homer works.
+  disneyplus_id:
   simpsonsworld_id: 299613763656
   good: false
   characters:
@@ -69,6 +76,7 @@ episodes:
   episode: 8
   description: Bart falls in love with the girl who moves in next door, only to find
     that she prefers the school bully.
+  disneyplus_id:
   simpsonsworld_id: 273542211871
   good: false
   characters:
@@ -78,6 +86,7 @@ episodes:
   season: 4
   episode: 9
   description: Homer and Barney vie for Springfield's lucrative snow plowing business.
+  disneyplus_id:
   simpsonsworld_id: 273544259768
   good: true
   characters:
@@ -88,6 +97,7 @@ episodes:
   episode: 10
   description: Marge recounts how Lisa first spoke as the family awaits baby Maggie's
     first word.
+  disneyplus_id:
   simpsonsworld_id: 288026691837
   good: false
   characters:
@@ -97,6 +107,7 @@ episodes:
   episode: 11
   description: Homer suffers a heart attack and hires Dr. Nick Riviera to perform
     a delicate triple bypass operation.
+  disneyplus_id:
   simpsonsworld_id: 273548355538
   good: true
   characters:
@@ -106,6 +117,7 @@ episodes:
   episode: 12
   description: An unscrupulous profiteer sells the people of Springfield on a defective
     monorail system, with Homer as the conductor.
+  disneyplus_id:
   simpsonsworld_id: 306386499796
   good: true
   characters:
@@ -116,6 +128,7 @@ episodes:
   episode: 13
   description: Selma decides to take her dead aunt's advice and have children before
     it is too late.
+  disneyplus_id:
   simpsonsworld_id: 310386755912
   good: true
   characters:
@@ -128,6 +141,7 @@ episodes:
   description: Bart tires of Homer's lack of interest in him and chooses another father
     from the Bigger Brother program.  Lisa struggles to kick the habit of dialing
     a 900 number.
+  disneyplus_id:
   simpsonsworld_id: 274103363992
   good: false
   characters:
@@ -139,6 +153,7 @@ episodes:
   episode: 15
   description: Lisa feels pity for Ralph, a nerdy classmate, and gives him a card
     on Valentine's Day. But to her horror, Ralph develops a crush on her.
+  disneyplus_id:
   simpsonsworld_id: 274107459686
   good: true
   characters:
@@ -149,6 +164,7 @@ episodes:
   episode: 16
   description: Marge convinces Homer he may have a drinking problem. Lisa plots to
     humiliate Bart with her science project after he ruins an experiment.
+  disneyplus_id:
   simpsonsworld_id: 277249603926
   good: true
   characters:
@@ -157,6 +173,7 @@ episodes:
   episode: 17
   description: Homer is elected union leader at the power plant and tries to save
     the dental plan so he will not have to pay for Lisa's new braces.
+  disneyplus_id:
   simpsonsworld_id: 357630019692
   good: true
   characters:
@@ -167,6 +184,7 @@ episodes:
   episode: 18
   description: Family and friends reminisce about Homer's life after Bart's April
     Fools' Day prank sends him to the hospital.
+  disneyplus_id:
   simpsonsworld_id: 305670723781
   good: false
   characters:
@@ -176,6 +194,7 @@ episodes:
   episode: 19
   description: Using Grandpa as a front, Lisa and Bart write their own "Itchy and
     Scratchy" cartoons.
+  disneyplus_id:
   simpsonsworld_id: 288029763650
   good: true
   characters:
@@ -187,6 +206,7 @@ episodes:
   episode: 20
   description: Lisa seeks to end a local holiday in which snakes are chased into town
     and beaten with sticks.  Bart is expelled from school by Principal Skinner.
+  disneyplus_id:
   simpsonsworld_id: 288129091929
   good: true
   characters:
@@ -195,6 +215,7 @@ episodes:
   episode: 21
   description: Marge is jailed when she is convicted of stealing from Apu's convenience
     store.
+  disneyplus_id:
   simpsonsworld_id: 299606595657
   good: false
   characters:
@@ -203,6 +224,7 @@ episodes:
   episode: 22
   description: Bart, Lisa and a group of celebrities help Krusty turn his career around
     after his television show is canceled.
+  disneyplus_id:
   simpsonsworld_id: 274256963874
   good: true
   characters:

--- a/episodes/season_05.yml
+++ b/episodes/season_05.yml
@@ -5,6 +5,7 @@ episodes:
   episode: 1
   description: Homer recounts his phenomenal rise to superstardom as a member of the
     barbershop quartet, The Be Sharps.
+  disneyplus_id:
   simpsonsworld_id: 305674307809
   good: false
   characters:
@@ -16,6 +17,7 @@ episodes:
   season: 5
   episode: 2
   description: Sideshow Bob terrorizes Bart after he is paroled from prison.
+  disneyplus_id:
   simpsonsworld_id: 305674819788
   good: true
   characters:
@@ -26,6 +28,7 @@ episodes:
   episode: 3
   description: Homer enrolls in a nuclear physics class at Springfield University
     and convinces three nerdy classmates to help him pull off a prank.
+  disneyplus_id:
   simpsonsworld_id: 280399427649
   good: true
   characters:
@@ -34,6 +37,7 @@ episodes:
   season: 5
   episode: 4
   description: The Simpsons find Mr. Burns' long-lost childhood teddy bear.
+  disneyplus_id:
   simpsonsworld_id: 279714371653
   good: true
   characters:
@@ -44,6 +48,7 @@ episodes:
   episode: 5
   description: In a ghoulish gallery, Bart hosts three bloodcurdling tales of Halloween
     horror.
+  disneyplus_id:
   simpsonsworld_id: 275206211805
   good: true
   characters:
@@ -53,6 +58,7 @@ episodes:
   episode: 6
   description: Marge joins divorcee Ruth Powers for a wild night on the town, only
     to discover that her friend is driving a stolen vehicle.
+  disneyplus_id:
   simpsonsworld_id: 294777411510
   good: true
   characters:
@@ -62,6 +68,7 @@ episodes:
   episode: 7
   description: The host of a self-help workshop convinces the people of Springfield
     they should emulate Bart's uninhibited personality.
+  disneyplus_id:
   simpsonsworld_id: 275202627817
   good: true
   characters:
@@ -71,6 +78,7 @@ episodes:
   episode: 8
   description: Bart inadvertently joins the Junior Campers, and during a rafting trip,
     he becomes lost at sea with Homer and Ned Flanders.
+  disneyplus_id:
   simpsonsworld_id: 288056387698
   good: true
   characters:
@@ -82,6 +90,7 @@ episodes:
   episode: 9
   description: Homer is attracted to a sexy co-worker with a personality identical
     to his own.
+  disneyplus_id:
   simpsonsworld_id: 275201091952
   good: true
   characters:
@@ -91,6 +100,7 @@ episodes:
   episode: 10
   description: Marge becomes addicted to playing slot machines after the town of Springfield
     legalizes gambling.
+  disneyplus_id:
   simpsonsworld_id: 305659459565
   good: true
   characters:
@@ -101,6 +111,7 @@ episodes:
   episode: 11
   description: Homer takes the law into his own hands after Springfield is victimized
     by a cat burglar.
+  disneyplus_id:
   simpsonsworld_id: 305677891810
   good: true
   characters:
@@ -110,6 +121,7 @@ episodes:
   episode: 12
   description: Bart becomes an instant celebrity after he ad-libs a line during a
     sketch on the "Krusty the Klown Show."
+  disneyplus_id:
   simpsonsworld_id: 302789187885
   good: true
   characters:
@@ -120,6 +132,7 @@ episodes:
   episode: 13
   description: Apu offers the Simpsons his services as valet after he is fired from
     the Kwik-E-Mart for selling rancid meat.
+  disneyplus_id:
   simpsonsworld_id: 279716931614
   good: false
   characters:
@@ -129,6 +142,7 @@ episodes:
   season: 5
   episode: 14
   description: Lisa manufactures her own talking doll for little girls.
+  disneyplus_id:
   simpsonsworld_id: 274260035625
   good: true
   characters:
@@ -138,6 +152,7 @@ episodes:
   episode: 15
   description: NASA scientists train Homer to become the first average American in
     space, with near disastrous results.
+  disneyplus_id:
   simpsonsworld_id: 275720259883
   good: true
   characters:
@@ -147,6 +162,7 @@ episodes:
   season: 5
   episode: 16
   description: Flanders is horrified to discover he has become Homer's best friend.
+  disneyplus_id:
   simpsonsworld_id: 310398019629
   good: maybe
   characters:
@@ -154,6 +170,7 @@ episodes:
   season: 5
   episode: 17
   description: Bart wins a full grown African elephant as part of a radio contest.
+  disneyplus_id:
   simpsonsworld_id: 275726403611
   good: maybe
   characters:
@@ -161,6 +178,7 @@ episodes:
   season: 5
   episode: 18
   description: Mr. Burns chooses Bart as the heir to his vast fortune.
+  disneyplus_id:
   simpsonsworld_id: 283747395787
   good: maybe
   characters:
@@ -169,6 +187,7 @@ episodes:
   episode: 19
   description: Bart suffers enormous guilt after Skinner is fired from his job as
     school principal.
+  disneyplus_id:
   simpsonsworld_id: 274260035741
   good: true
   characters:
@@ -180,6 +199,7 @@ episodes:
   description: Only Bart can clear Mayor Quimby's nephew of an assault charge, but
     he fears that identifying himself as a witness will mean expulsion for skipping
     class.
+  disneyplus_id:
   simpsonsworld_id: 278796355962
   good: true
   characters:
@@ -190,6 +210,7 @@ episodes:
   episode: 21
   description: Grampa and Mr. Burns vie for Mrs. Bouvier's hand in marriage.  Bart
     purchases a worthless Itchy and Scratchy animation cell.
+  disneyplus_id:
   simpsonsworld_id: 305681987583
   good: maybe
   characters:
@@ -198,6 +219,7 @@ episodes:
   episode: 22
   description: Marge kicks Homer out of the house after she discovers that he revealed
     her personal secrets to an adult education class.
+  disneyplus_id:
   simpsonsworld_id: 279720003973
   good: true
   characters:

--- a/episodes/season_06.yml
+++ b/episodes/season_06.yml
@@ -5,6 +5,7 @@ episodes:
   episode: 1
   description: Bart believes he witnessed Ned Flanders murder his wife.  Lisa's popularity
     soars after her family buys a swimming pool during a heat wave.
+  disneyplus_id:
   simpsonsworld_id: 300925507538
   good: true
   characters:
@@ -17,6 +18,7 @@ episodes:
   description: Lisa becomes jealous when she meets a new student who is even more
     intelligent than herself.  Homer acquires a truckload of white sugar, thinking
     it will net him a fortune.
+  disneyplus_id:
   simpsonsworld_id: 278809667691
   good: false
   characters:
@@ -27,6 +29,7 @@ episodes:
   episode: 3
   description: When Marge suspects that romance has gone out of her life, her family
     recalls romantic encounters from their past.
+  disneyplus_id:
   simpsonsworld_id: 300928067775
   good: false
   characters:
@@ -36,6 +39,7 @@ episodes:
   episode: 4
   description: The Simpsons visit a theme park based on the gratuitously violent Itchy
     and Scratchy cartoons.
+  disneyplus_id:
   simpsonsworld_id: 283752003577
   good: true
   characters:
@@ -45,6 +49,7 @@ episodes:
   episode: 5
   description: Sideshow Bob runs for political office after Mayor Quimby pardons him
     from prison.
+  disneyplus_id:
   simpsonsworld_id: 275729987504
   good: true
   characters:
@@ -54,6 +59,7 @@ episodes:
   season: 6
   episode: 6
   description: The Simpsons spin three tales of Halloween horror.
+  disneyplus_id:
   simpsonsworld_id: 299597891663
   good: true
   characters:
@@ -63,6 +69,7 @@ episodes:
   episode: 7
   description: Bart falls in love with Reverend Lovejoy's beautiful daughter, only
     to discover that she is more of a hellion than he is.
+  disneyplus_id:
   simpsonsworld_id: 275744323759
   good: true
   characters:
@@ -72,6 +79,7 @@ episodes:
   episode: 8
   description: Lisa joins a hockey team and finds herself pitted against Bart in a
     critical game.
+  disneyplus_id:
   simpsonsworld_id: 275746371575
   good: true
   characters:
@@ -81,6 +89,7 @@ episodes:
   season: 6
   episode: 9
   description: Homer is wrongly accused of committing sexual harassment.
+  disneyplus_id:
   simpsonsworld_id: 275746883653
   good: true
   characters:
@@ -90,6 +99,7 @@ episodes:
   episode: 10
   description: While selling a homemade tonic guaranteed to increase sexual desire
     in men, Grampa reveals that Homer's conception was accidental.
+  disneyplus_id:
   simpsonsworld_id: 274264643876
   good: true
   characters:
@@ -100,6 +110,7 @@ episodes:
   episode: 11
   description: Marge seeks professional help from a psychiatrist after realizing she
     is afraid to fly.
+  disneyplus_id:
   simpsonsworld_id: 305684547546
   good: false
   characters:
@@ -109,6 +120,7 @@ episodes:
   episode: 12
   description: Homer's popularity skyrockets when he is chosen as the leader of a
     secret organization.
+  disneyplus_id:
   simpsonsworld_id: 275745859881
   good: true
   characters:
@@ -117,6 +129,7 @@ episodes:
   season: 6
   episode: 13
   description: Homer recounts how Maggie's accidental birth changed his life forever.
+  disneyplus_id:
   simpsonsworld_id: 278796867754
   good: false
   characters:
@@ -124,6 +137,7 @@ episodes:
   season: 6
   episode: 14
   description: Bart discovers a comet that is on a collision course with Springfield.
+  disneyplus_id:
   simpsonsworld_id: 275746883888
   good: true
   characters:
@@ -132,6 +146,7 @@ episodes:
   season: 6
   episode: 15
   description: Homer enrolls in a clown college franchised by Krusty the Clown.
+  disneyplus_id:
   simpsonsworld_id: 279723587611
   good: true
   characters:
@@ -142,6 +157,7 @@ episodes:
   episode: 16
   description: Bart must apologize to the country of Australia after he tricks a boy
     from down under into accepting an expensive collect call.
+  disneyplus_id:
   simpsonsworld_id: 275748931680
   good: true
   characters:
@@ -151,6 +167,7 @@ episodes:
   episode: 17
   description: Homer is forced to borrow money from Patty and Selma after he wipes
     out the family's savings by investing in pumpkins.
+  disneyplus_id:
   simpsonsworld_id: 305686083529
   good: true
   characters:
@@ -162,6 +179,7 @@ episodes:
   episode: 18
   description: Homer grows jealous after Marge asks critic Jay Sherman to co-judge
     Springfield's film festival.
+  disneyplus_id:
   simpsonsworld_id: 283753539580
   good: true
   characters:
@@ -172,6 +190,7 @@ episodes:
   episode: 19
   description: A fortune teller describes how a genteel Englishman will ask for Lisa's
     hand in marriage in the year 2010.
+  disneyplus_id:
   simpsonsworld_id: 275751491511
   good: false
   characters:
@@ -181,6 +200,7 @@ episodes:
   episode: 20
   description: Bart and Lisa attempt to rescue 25 greyhound puppies from Mr. Burns,
     who wants to use their hides for a new tuxedo.
+  disneyplus_id:
   simpsonsworld_id: 278807107855
   good: true
   characters:
@@ -192,6 +212,7 @@ episodes:
   episode: 21
   description: Bart masterminds a teacher's strike, but is humiliated when Marge takes
     charge of his class.
+  disneyplus_id:
   simpsonsworld_id: 294780995610
   good: true
   characters:
@@ -202,6 +223,7 @@ episodes:
   episode: 22
   description: Lisa is saddened by the death of blues great Bleeding Gums Murphy.  Bart
     ingests a piece of jagged metal while eating Krusty-O cereal.
+  disneyplus_id:
   simpsonsworld_id: 275755587777
   good: true
   characters:
@@ -212,6 +234,7 @@ episodes:
   season: 6
   episode: 23
   description: Marge joins the police force.
+  disneyplus_id:
   simpsonsworld_id: 305689155572
   good: true
   characters:
@@ -222,6 +245,7 @@ episodes:
   episode: 24
   description: Bart and his friends march on Shelbyville when Springfield's lemon
     tree is stolen by a gang of children from across the border.
+  disneyplus_id:
   simpsonsworld_id: 274269763684
   good: true
   characters:
@@ -233,6 +257,7 @@ episodes:
   description: Just about everyone in Springfield vows to kill Mr. Burns after he
     cheats the elementary school out of a newly discovered oil well and threatens
     to block out the sun.
+  disneyplus_id:
   simpsonsworld_id: 294781507859
   good: true
   characters:

--- a/episodes/season_07.yml
+++ b/episodes/season_07.yml
@@ -4,6 +4,7 @@ episodes:
   season: 7
   episode: 1
   description: Lisa aids police with the investigation of the Burns shooting.
+  disneyplus_id:
   simpsonsworld_id: 305689667892
   good: true
   characters:
@@ -12,6 +13,7 @@ episodes:
   episode: 2
   description: Hollywood producers cast Milhouse in a motion picture based on the
     popular "Radioactive Man" comic books.
+  disneyplus_id:
   simpsonsworld_id: 305693251940
   good: true
   characters:
@@ -20,6 +22,7 @@ episodes:
   episode: 3
   description: The Flanders gain custody of the Simpson children after welfare workers
     accuse Homer and Marge of being negligent parents.
+  disneyplus_id:
   simpsonsworld_id: 306174019869
   good: true
   characters:
@@ -28,6 +31,7 @@ episodes:
   episode: 4
   description: Bart sells his soul to Milhouse for five dollars.  Moe transforms his
     bar into a family restaurant.
+  disneyplus_id:
   simpsonsworld_id: 276972099995
   good: true
   characters:
@@ -35,6 +39,7 @@ episodes:
   season: 7
   episode: 5
   description: Lisa turns vegetarian after her family visits a petting zoo.
+  disneyplus_id:
   simpsonsworld_id: 276980291592
   good: true
   characters:
@@ -42,6 +47,7 @@ episodes:
   season: 7
   episode: 6
   description: The Simpsons appear in three horrifying Halloween tales.
+  disneyplus_id:
   simpsonsworld_id: 310404163601
   good: true
   characters:
@@ -51,6 +57,7 @@ episodes:
   episode: 7
   description: Homer intentionally gains weight so he can qualify for disability and
     work at home.
+  disneyplus_id:
   simpsonsworld_id: 294786627843
   good: true
   characters:
@@ -59,6 +66,7 @@ episodes:
   episode: 8
   description: After Homer fakes his own death, his long-thought-deceased mother arrives
     in Springfield to pay her last respects.
+  disneyplus_id:
   simpsonsworld_id: 276983875726
   good: true
   characters:
@@ -67,6 +75,7 @@ episodes:
   episode: 9
   description: Sideshow Bob threatens to detonate a nuclear bomb unless television
     is abolished.
+  disneyplus_id:
   simpsonsworld_id: 302792771516
   good: true
   characters:
@@ -75,6 +84,7 @@ episodes:
   episode: 10
   description: Troy McClure hosts this special 138th episode, which includes the first-ever
     cartoon shorts, trivia questions, and never-before-seen footage.
+  disneyplus_id:
   simpsonsworld_id: 324451395934
   good: true
   characters:
@@ -83,6 +93,7 @@ episodes:
   episode: 11
   description: As Christmas approaches, Marge treats Bart like an adult after he is
     caught shoplifting.
+  disneyplus_id:
   simpsonsworld_id: 305669699710
   good: true
   characters:
@@ -92,6 +103,7 @@ episodes:
   description: Homer reluctantly accepts Mr. Burns into his new bowling league.  Bart
     causes a student riot by wearing a Mad magazine iron-on prompting Skinner to implement
     a school dress code.
+  disneyplus_id:
   simpsonsworld_id: 302792771967
   good: true
   characters:
@@ -100,6 +112,7 @@ episodes:
   episode: 13
   description: Former President George Bush and his wife Barbara buy a house across
     the street from the Simpsons.
+  disneyplus_id:
   simpsonsworld_id: 276994115834
   good: true
   characters:
@@ -107,6 +120,7 @@ episodes:
   season: 7
   episode: 14
   description: The Simpsons apply for membership at a posh country club.
+  disneyplus_id:
   simpsonsworld_id: 305694276001
   good: true
   characters:
@@ -115,6 +129,7 @@ episodes:
   episode: 15
   description: Krusty is arrested for massive tax fraud after Bart inadvertently exposes
     his hero's illegal bank account.
+  disneyplus_id:
   simpsonsworld_id: 301346371709
   good: true
   characters:
@@ -123,6 +138,7 @@ episodes:
   episode: 16
   description: Lisa discovers that Jebediah Springfield was a vicious pirate. Homer
     wins the coveted role of town crier in an upcoming parade.
+  disneyplus_id:
   simpsonsworld_id: 302796355658
   good: true
   characters:
@@ -130,6 +146,7 @@ episodes:
   season: 7
   episode: 17
   description: Homer acts as Mr. Burns' assistant while Smithers is away on vacation.
+  disneyplus_id:
   simpsonsworld_id: 277248579634
   good: true
   characters:
@@ -138,6 +155,7 @@ episodes:
   episode: 18
   description: Bart and Lisa come to the aid of a down-and-out man who claims to have
     invented the concept of cartoon violence.
+  disneyplus_id:
   simpsonsworld_id: 301668931982
   good: true
   characters:
@@ -145,6 +163,7 @@ episodes:
   season: 7
   episode: 19
   description: Troy McClure stages a Hollywood comeback when he begins dating Selma.
+  disneyplus_id:
   simpsonsworld_id: 300935235544
   good: true
   characters:
@@ -154,6 +173,7 @@ episodes:
   description: Using a fake driver's license, Bart rents a car and embarks on a Spring
     Break road trip with his friends.  A special bond develops between Lisa and Homer
     after Skinner invents Go To Work With Your Parents Day.
+  disneyplus_id:
   simpsonsworld_id: 277000259951
   good: true
   characters:
@@ -162,6 +182,7 @@ episodes:
   episode: 21
   description: The lives of Springfield residents are highlighted in a series of interconnecting
     vignettes.
+  disneyplus_id:
   simpsonsworld_id: 299588163608
   good: true
   characters:
@@ -171,6 +192,7 @@ episodes:
   episode: 22
   description: Grampa and Mr. Burns, the last surviving members of a World War II
     army unit, vie for a priceless collection of rare art hidden in a secret location.
+  disneyplus_id:
   simpsonsworld_id: 279728707597
   good: true
   characters:
@@ -179,6 +201,7 @@ episodes:
   episode: 23
   description: Apu faces deportation when a referendum on illegal immigrants is placed
     on the Springfield ballot.
+  disneyplus_id:
   simpsonsworld_id: 310404675978
   good: true
   characters:
@@ -186,6 +209,7 @@ episodes:
   season: 7
   episode: 24
   description: Homer is hired to perform in a rock festival.
+  disneyplus_id:
   simpsonsworld_id: 277008451637
   good: true
   characters:
@@ -194,6 +218,7 @@ episodes:
   episode: 25
   description: While on summer vacation with her family, Lisa sheds her nerdy image
     in an effort to make new friends.
+  disneyplus_id:
   simpsonsworld_id: 277013571573
   good: true
   characters:

--- a/episodes/season_08.yml
+++ b/episodes/season_08.yml
@@ -6,6 +6,7 @@ episodes:
   description: 'The Simpsons appear in three tales of terror: Bart discovers an evil
     twin brother living in the attic; Lisa creates a microscopic society; and space
     aliens transform themselves into Clinton and Dole look-alikes.'
+  disneyplus_id:
   simpsonsworld_id: 299625027835
   good: true
   characters:
@@ -15,6 +16,7 @@ episodes:
   episode: 2
   description: The Simpsons relocate to another community after Homer unwittingly
     takes a job with a company controlled by a super-villain.
+  disneyplus_id:
   simpsonsworld_id: 306390595776
   good: true
   characters:
@@ -23,6 +25,7 @@ episodes:
   episode: 3
   description: Homer becomes a professional boxer when doctors discover he was born
     with a unique genetic condition that protects his brain from injury.
+  disneyplus_id:
   simpsonsworld_id: 288058947803
   good: true
   characters:
@@ -30,6 +33,7 @@ episodes:
   season: 8
   episode: 4
   description: With Homer's help, Mr. Burns' long-lost son stages his own kidnapping.
+  disneyplus_id:
   simpsonsworld_id: 299622467514
   good: false
   characters:
@@ -38,6 +42,7 @@ episodes:
   episode: 5
   description: While Marge is out of town, Homer allows Bart to work at a burlesque
     house.
+  disneyplus_id:
   simpsonsworld_id: 294789699801
   good: true
   characters:
@@ -46,6 +51,7 @@ episodes:
   episode: 6
   description: When Milhouse's parents get a divorce, Homer grows convinced that his
     own marriage is in jeopardy.
+  disneyplus_id:
   simpsonsworld_id: 277025347786
   good: true
   characters:
@@ -54,6 +60,7 @@ episodes:
   episode: 7
   description: Lisa develops a crush on bully Nelson Muntz.  Homer uses an automatic
     telephone dialer for an electronic panhandling scheme.
+  disneyplus_id:
   simpsonsworld_id: 306394691862
   good: true
   characters:
@@ -61,6 +68,7 @@ episodes:
   season: 8
   episode: 8
   description: Ned Flanders suffers a breakdown after his home is destroyed by a hurricane.
+  disneyplus_id:
   simpsonsworld_id: 436250179702
   good: true
   characters:
@@ -70,6 +78,7 @@ episodes:
   description: After ingesting several Guatemalan peppers during chili cook-off, Homer
     experiences hallucinatory visions that inspire him to find his true soul mate
     in life.
+  disneyplus_id:
   simpsonsworld_id: 436252739905
   good: true
   characters:
@@ -78,6 +87,7 @@ episodes:
   episode: 10
   description: X-Files Agents Mulder and Scully investigate Homer's encounter with
     an alleged extraterrestrial.
+  disneyplus_id:
   simpsonsworld_id: 436259395954
   good: true
   characters:
@@ -86,6 +96,7 @@ episodes:
   episode: 11
   description: After being expelled from an investment club, Marge starts her own
     pretzel franchise.
+  disneyplus_id:
   simpsonsworld_id: 436264515927
   good: true
   characters:
@@ -94,6 +105,7 @@ episodes:
   episode: 12
   description: Homer and Mr. Burns are buried beneath an avalanche during a survival
     trek in the mountains.
+  disneyplus_id:
   simpsonsworld_id: 436267075791
   good: true
   characters:
@@ -102,6 +114,7 @@ episodes:
   episode: 13
   description: The Simpsons hire a Mary Poppins-like nanny when Marge becomes overwhelmed
     by the demands of being a housewife.
+  disneyplus_id:
   simpsonsworld_id: 436271683676
   good: true
   characters:
@@ -111,6 +124,7 @@ episodes:
   description: When ratings for Itchy & Scratchy cartoons plummet, a studio committee
     creates a new, hipper character and hires Homer to provide the voice. Presented
     by FXX.
+  disneyplus_id:
   simpsonsworld_id: 436278339668
   good: true
   characters:
@@ -119,6 +133,7 @@ episodes:
   episode: 15
   description: Homer grows homophobic after he realizes the family's new friend is
     gay.
+  disneyplus_id:
   simpsonsworld_id: 436284995621
   good: true
   characters:
@@ -128,6 +143,7 @@ episodes:
   description: Bart fears the worst when Sideshow Bob wins release from prison by
     claiming he is a reformed man and is hired by his brother to work on a construction
     project.
+  disneyplus_id:
   simpsonsworld_id: 436296259771
   good: true
   characters:
@@ -135,6 +151,7 @@ episodes:
   season: 8
   episode: 17
   description: Homer and Marge allow Lisa to baby-sit Bart.
+  disneyplus_id:
   simpsonsworld_id: 436301891875
   good: false
   characters:
@@ -143,6 +160,7 @@ episodes:
   episode: 18
   description: Homer turns bootlegger when Springfield enforces an antiquated prohibition
     law.
+  disneyplus_id:
   simpsonsworld_id: 436402755605
   good: true
   characters:
@@ -150,6 +168,7 @@ episodes:
   season: 8
   episode: 19
   description: Bart exposes Skinner and Krabappel's clandestine affair.
+  disneyplus_id:
   simpsonsworld_id: 436412995642
   good: true
   characters:
@@ -158,6 +177,7 @@ episodes:
   episode: 20
   description: Bart gives away Santa's Little Helper so he can keep a fully trained,
     blue ribbon Collie.
+  disneyplus_id:
   simpsonsworld_id: 436370499586
   good: false
   characters:
@@ -166,6 +186,7 @@ episodes:
   episode: 21
   description: Lisa helps Mr. Burns build a recycling center after a series of bad
     investments costs the multimillionaire his fortune.
+  disneyplus_id:
   simpsonsworld_id: 436383811985
   good: true
   characters:
@@ -174,6 +195,7 @@ episodes:
   episode: 22
   description: Marge becomes a church volunteer.  Homer discovers his image printed
     on a box of Japanese dish detergent.
+  disneyplus_id:
   simpsonsworld_id: 436438595644
   good: true
   characters:
@@ -182,6 +204,7 @@ episodes:
   episode: 23
   description: A resentful, hard-working employee at the power plant makes Homer his
     enemy.  Bart purchases an abandoned factory for one dollar at a government auction.
+  disneyplus_id:
   simpsonsworld_id: 436466755640
   good: true
   characters:
@@ -189,6 +212,7 @@ episodes:
   season: 8
   episode: 24
   description: Troy McClure hosts three spin-offs from "The Simpsons" television show.
+  disneyplus_id:
   simpsonsworld_id: 436481091875
   good: false
   characters:
@@ -197,6 +221,7 @@ episodes:
   episode: 25
   description: Cadets give Lisa the "silent treatment" when she enrolls in an all-male
     military academy.
+  disneyplus_id:
   simpsonsworld_id: 1071844931909
   good: true
   characters:

--- a/episodes/season_09.yml
+++ b/episodes/season_09.yml
@@ -4,6 +4,7 @@ episodes:
   season: 9
   episode: 1
   description: The Simpsons journey to New York City to retrieve the family car.
+  disneyplus_id:
   simpsonsworld_id: 436516931611
   good: true
   characters:
@@ -11,6 +12,7 @@ episodes:
   season: 9
   episode: 2
   description: A stranger claims that Principal Skinner is an impostor.
+  disneyplus_id:
   simpsonsworld_id: 436505155662
   good: true
   characters:
@@ -18,6 +20,7 @@ episodes:
   season: 9
   episode: 3
   description: Homer and Marge recount how Lisa got her saxophone.
+  disneyplus_id:
   simpsonsworld_id: 279743555749
   good: false
   characters:
@@ -27,6 +30,7 @@ episodes:
   description: Homer battles killer mutants after Springfield is destroyed by a nuclear
     blast; a matter- transportation device melds Bart with a housefly; in Colonial
     times, Marge is accused of being a witch.
+  disneyplus_id:
   simpsonsworld_id: 279170627965
   good: true
   characters:
@@ -35,6 +39,7 @@ episodes:
   season: 9
   episode: 5
   description: Homer purchases a handgun to protect his family.
+  disneyplus_id:
   simpsonsworld_id: 302813251779
   good: true
   characters:
@@ -43,6 +48,7 @@ episodes:
   episode: 6
   description: Homer becomes coach of the Springfield Pee Wee Football team and appoints
     Bart as starting quarterback.
+  disneyplus_id:
   simpsonsworld_id: 448293443714
   good: false
   characters:
@@ -51,6 +57,7 @@ episodes:
   episode: 7
   description: In an effort to annul an arranged marriage, Apu tells his mother he
     wed Marge.
+  disneyplus_id:
   simpsonsworld_id: 279177283545
   good: false
   characters:
@@ -59,6 +66,7 @@ episodes:
   episode: 8
   description: Townspeople believe Lisa has unearthed the fossilized remains of an
     angel.
+  disneyplus_id:
   simpsonsworld_id: 279180355540
   good: true
   characters:
@@ -67,6 +75,7 @@ episodes:
   episode: 9
   description: Marge gets a job with a realty firm, but her honesty costs her lucrative
     sales.  Homer purchases a 60s hot-rod convertible at a police auction.
+  disneyplus_id:
   simpsonsworld_id: 280404547525
   good: true
   characters:
@@ -75,6 +84,7 @@ episodes:
   episode: 10
   description: People throughout Springfield open their hearts and wallets after Bart
     claims the family's Christmas presents were stolen by a burglar.
+  disneyplus_id:
   simpsonsworld_id: 306881091696
   good: false
   characters:
@@ -82,6 +92,7 @@ episodes:
   season: 9
   episode: 11
   description: The Simpsons recall their many musical moments from seasons past.
+  disneyplus_id:
   simpsonsworld_id: 294808131518
   good: false
   characters:
@@ -90,6 +101,7 @@ episodes:
   episode: 12
   description: A carnival worker and his son move in with the Simpsons after Homer
     costs them their jobs.
+  disneyplus_id:
   simpsonsworld_id: 302818371931
   good: true
   characters:
@@ -98,6 +110,7 @@ episodes:
   episode: 13
   description: Marge tries her hand at deprogramming after her family is brainwashed
     by a religious cult.
+  disneyplus_id:
   simpsonsworld_id: 299627075941
   good: true
   characters:
@@ -106,6 +119,7 @@ episodes:
   episode: 14
   description: Bart, Lisa and their classmates fight for survival when they become
     stranded on a remote island.  Homer starts his own business on the Internet.
+  disneyplus_id:
   simpsonsworld_id: 448356931860
   good: false
   characters:
@@ -114,6 +128,7 @@ episodes:
   episode: 15
   description: Krusty shuns his old routines in favor of edgier material and suddenly
     becomes the hottest comic in show business.
+  disneyplus_id:
   simpsonsworld_id: 294812739638
   good: true
   characters:
@@ -122,6 +137,7 @@ episodes:
   episode: 16
   description: When Moe goes broke romancing his new love, he enlists Homer in a scheme
     to collect on an insurance policy.
+  disneyplus_id:
   simpsonsworld_id: 283910211639
   good: true
   characters:
@@ -130,6 +146,7 @@ episodes:
   episode: 17
   description: Lisa fears she is genetically predisposed to lose her intelligence.
     Apu uses a frozen Jasper as a tourist attraction.
+  disneyplus_id:
   simpsonsworld_id: 299651139676
   good: true
   characters:
@@ -137,6 +154,7 @@ episodes:
   season: 9
   episode: 18
   description: Bart is appalled when Marge pairs him with Ralph Wiggum.
+  disneyplus_id:
   simpsonsworld_id: 299639875678
   good: false
   characters:
@@ -144,6 +162,7 @@ episodes:
   season: 9
   episode: 19
   description: Homer becomes the captain of a Navy submarine.  Bart gets his ear pierced.
+  disneyplus_id:
   simpsonsworld_id: 302809667837
   good: true
   characters:
@@ -152,6 +171,7 @@ episodes:
   episode: 20
   description: When a tax audit lands him in hot water, Homer goes undercover for
     the government and attempts to retrieve a trillion dollar note from Mr. Burns.
+  disneyplus_id:
   simpsonsworld_id: 299644483816
   good: false
   characters:
@@ -160,6 +180,7 @@ episodes:
   episode: 21
   description: Bart attempts to upstage Lisa when the pair co-host a children's news
     program.  Homer obtains a helper monkey.
+  disneyplus_id:
   simpsonsworld_id: 299672131928
   good: true
   characters:
@@ -168,6 +189,7 @@ episodes:
   episode: 22
   description: Homer enters the race for Sanitation Commissioner after garbage men
     refuse to collect his trash.
+  disneyplus_id:
   simpsonsworld_id: 307101763818
   good: true
   characters:
@@ -176,6 +198,7 @@ episodes:
   episode: 23
   description: After improving his physique, Homer attempts to climb a treacherous
     mountain.
+  disneyplus_id:
   simpsonsworld_id: 467593795648
   good: false
   characters:
@@ -184,6 +207,7 @@ episodes:
   episode: 24
   description: Lisa gets lost in an unfamiliar part of town while searching for a
     museum. Bart adheres novelties to his face only to discover they cannot be removed.
+  disneyplus_id:
   simpsonsworld_id: 467595331852
   good: true
   characters:
@@ -192,6 +216,7 @@ episodes:
   episode: 25
   description: Homer and Marge discover the secret to reigniting their sex life. Bart
     and Lisa hunt for hidden treasure using Grampa's old mine sweeper.
+  disneyplus_id:
   simpsonsworld_id: 467599939876
   good: false
   characters:

--- a/episodes/season_10.yml
+++ b/episodes/season_10.yml
@@ -5,6 +5,7 @@ episodes:
   episode: 1
   description: Homer thinks he can net a fortune by recycling grease.  Lisa helps
     organize a school dance.
+  disneyplus_id:
   simpsonsworld_id: 292933187533
   good: true
   characters:
@@ -13,6 +14,7 @@ episodes:
   episode: 2
   description: After realizing half his life is over, Homer decides to become the
     next Thomas Edison.
+  disneyplus_id:
   simpsonsworld_id: 473117763575
   good: true
   characters:
@@ -21,6 +23,7 @@ episodes:
   episode: 3
   description: Bart tends to a nest filled with eggs after he inadvertently kills
     a bird with a BB gun.
+  disneyplus_id:
   simpsonsworld_id: 473109571557
   good: true
   characters:
@@ -30,6 +33,7 @@ episodes:
   description: An evil toupee possesses Homer; Bart and Lisa find themselves trapped
     inside an Itchy & Scratchy cartoon; baby Maggie turns out to be the daughter of
     a space alien.
+  disneyplus_id:
   simpsonsworld_id: 473130051681
   good: true
   characters:
@@ -39,6 +43,7 @@ episodes:
   episode: 5
   description: Homer befriends a group of Hollywood celebrities vacationing in a remote
     part of town and promises to keep their whereabouts a secret.
+  disneyplus_id:
   simpsonsworld_id: 473147459674
   good: false
   characters:
@@ -46,6 +51,7 @@ episodes:
   season: 10
   episode: 6
   description: Homer embraces his newly discovered hippie heritage.
+  disneyplus_id:
   simpsonsworld_id: 473138243754
   good: false
   characters:
@@ -54,6 +60,7 @@ episodes:
   episode: 7
   description: Lisa suffers a guilty conscience after she cheats on an exam.  Homer
     believes he will save a fortune by raising his own lobster.
+  disneyplus_id:
   simpsonsworld_id: 473152579638
   good: true
   characters:
@@ -62,6 +69,7 @@ episodes:
   episode: 8
   description: Homer offers to donate one of his kidneys to Grampa until he realizes
     the surgery will place his own life in jeopardy.
+  disneyplus_id:
   simpsonsworld_id: 473158211896
   good: false
   characters:
@@ -69,6 +77,7 @@ episodes:
   season: 10
   episode: 9
   description: Homer takes on the mob when he acts as Mayor Quimby's bodyguard.
+  disneyplus_id:
   simpsonsworld_id: 473163843671
   good: true
   characters:
@@ -76,6 +85,7 @@ episodes:
   season: 10
   episode: 10
   description: Homer shows Flanders how to enjoy life by taking him to Las Vegas.
+  disneyplus_id:
   simpsonsworld_id: 473115203586
   good: false
   characters:
@@ -83,6 +93,7 @@ episodes:
   season: 10
   episode: 11
   description: The children of Springfield rebel after Wiggum enforces a curfew.
+  disneyplus_id:
   simpsonsworld_id: 473155651508
   good: true
   characters:
@@ -91,6 +102,7 @@ episodes:
   episode: 12
   description: Homer and his friends eagerly anticipate attending the Super Bowl until
     a ticketing snafu threatens to keep them from seeing the game.
+  disneyplus_id:
   simpsonsworld_id: 473132611959
   good: false
   characters:
@@ -99,6 +111,7 @@ episodes:
   episode: 13
   description: Homer changes his name when a dimwitted television show character named
     "Homer Simpson" becomes an overnight sensation.
+  disneyplus_id:
   simpsonsworld_id: 473140803870
   good: false
   characters:
@@ -107,6 +120,7 @@ episodes:
   episode: 14
   description: Apu showers his wife with Valentine's Day surprises making men throughout
     Springfield look like cheapskates.
+  disneyplus_id:
   simpsonsworld_id: 473104963819
   good: true
   characters:
@@ -115,6 +129,7 @@ episodes:
   episode: 15
   description: Marge discovers the pleasures of driving a sport utility vehicle until
     aggressive highway habits cost her.
+  disneyplus_id:
   simpsonsworld_id: 473097795997
   good: true
   characters:
@@ -123,6 +138,7 @@ episodes:
   episode: 16
   description: Lisa exhibits signs of stress when she is forced into sharing her brother's
     bedroom.  Marge becomes addicted to eavesdropping on cellular phone conversations.
+  disneyplus_id:
   simpsonsworld_id: 473093187636
   good: false
   characters:
@@ -131,6 +147,7 @@ episodes:
   episode: 17
   description: Homer and Bart attempt to deliver a dead trucker's cargo on schedule.  Meanwhile,
     Marge decides to have an adventure of her own and purchases a new doorbell.
+  disneyplus_id:
   simpsonsworld_id: 473095235738
   good: true
   characters:
@@ -140,6 +157,7 @@ episodes:
   description: While listening to one of Reverend Lovejoy's sermons on a sweltering
     Easter Sunday morning, the Simpsons fall asleep and envision themselves as characters
     from the Bible.
+  disneyplus_id:
   simpsonsworld_id: 299678275566
   good: false
   characters:
@@ -148,6 +166,7 @@ episodes:
   episode: 19
   description: Homer pursues a career as an artist when his misshapen barbecue pit
     attracts the attention of a gallery.
+  disneyplus_id:
   simpsonsworld_id: 310457411688
   good: true
   characters:
@@ -155,6 +174,7 @@ episodes:
   season: 10
   episode: 20
   description: Bart must perform community service at Grampa's retirement home.
+  disneyplus_id:
   simpsonsworld_id: 279757379586
   good: true
   characters:
@@ -163,6 +183,7 @@ episodes:
   episode: 21
   description: Mr. Burns attempts to win adoration by transporting the Loch Ness monster
     to Springfield.
+  disneyplus_id:
   simpsonsworld_id: 310427203648
   good: false
   characters:
@@ -170,6 +191,7 @@ episodes:
   season: 10
   episode: 22
   description: Lisa is invited to join Mensa; Homer receives a free erotic photo session.
+  disneyplus_id:
   simpsonsworld_id: 306868803826
   good: false
   characters:
@@ -178,6 +200,7 @@ episodes:
   episode: 23
   description: The Simpsons board a mega-saver flight for Tokyo, only to find themselves
     trapped overseas when they run out of money.
+  disneyplus_id:
   simpsonsworld_id: 306901571847
   good: true
   characters:

--- a/episodes/season_11.yml
+++ b/episodes/season_11.yml
@@ -5,6 +5,7 @@ episodes:
   episode: 1
   description: Studio executives panic when actor Mel Gibson taps Homer to help him
     retool his latest film.
+  disneyplus_id:
   simpsonsworld_id: 306906179700
   good: true
   characters:
@@ -14,6 +15,7 @@ episodes:
   episode: 2
   description: Bart is diagnosed with Attention Deficit Disorder and placed on medication
     that quells his disruptive behavior.
+  disneyplus_id:
   simpsonsworld_id: 302833219678
   good: false
   characters:
@@ -23,6 +25,7 @@ episodes:
   episode: 3
   description: Homer becomes the Springfield Shopper's new food critic, but raises
     the ire of restaurateurs by panning their cooking.
+  disneyplus_id:
   simpsonsworld_id: 306911811691
   good: true
   characters:
@@ -33,6 +36,7 @@ episodes:
   description: Homer's Y2K error plunges the Earth into chaos; Bart and Lisa become
     superheroes and attempt to save Lucy Lawless from a super-villain; someone terrorizes
     the family after Marge kills Ned Flanders.
+  disneyplus_id:
   simpsonsworld_id: 307851843709
   good: true
   characters:
@@ -42,6 +46,7 @@ episodes:
   episode: 5
   description: The Simpsons relocate to a farm, where Homer produces a tomato that
     is highly addictive.
+  disneyplus_id:
   simpsonsworld_id: 302847555697
   good: true
   characters:
@@ -50,6 +55,7 @@ episodes:
   episode: 6
   description: Homer becomes an instant celebrity when he bowls a perfect game.  But
     when his fame fades away, he lavishes his time on baby Maggie.
+  disneyplus_id:
   simpsonsworld_id: 294762563857
   good: true
   characters:
@@ -59,6 +65,7 @@ episodes:
   season: 11
   episode: 7
   description: Apu is driven to the brink when his wife, Manjula, gives birth to octuplets.
+  disneyplus_id:
   simpsonsworld_id: 306920003903
   good: false
   characters:
@@ -68,6 +75,7 @@ episodes:
   episode: 8
   description: Homer wins a vintage motorcycle during a dance contest - and attracts
     the attention of Hell's Satans when he forms his own gang.
+  disneyplus_id:
   simpsonsworld_id: 301643843522
   good: true
   characters:
@@ -79,6 +87,7 @@ episodes:
   description: As the Christmas holiday approaches... Springfield Elementary closes
     its doors for financial reasons, only to reopen when a mysterious organization
     steps in to help.
+  disneyplus_id:
   simpsonsworld_id: 848995395938
   good: false
   characters:
@@ -89,6 +98,7 @@ episodes:
   episode: 10
   description: Lisa becomes mother-of-the-house when Marge is hospitalized with a
     broken leg.
+  disneyplus_id:
   simpsonsworld_id: 300903491898
   good: true
   characters:
@@ -96,6 +106,7 @@ episodes:
   season: 11
   episode: 11
   description: Bart believes he has the power to heal the sick.
+  disneyplus_id:
   simpsonsworld_id: 300909123775
   good: false
   characters:
@@ -104,6 +115,7 @@ episodes:
   episode: 12
   description: The Simpsons care for Burns' mansion when the billionaire leaves town
     for a medical exam.
+  disneyplus_id:
   simpsonsworld_id: 279747651734
   good: true
   characters:
@@ -114,6 +126,7 @@ episodes:
   episode: 13
   description: When Homer and Bart transform a loser racehorse into a champion, rival
     jockeys threaten revenge.
+  disneyplus_id:
   simpsonsworld_id: 306926659533
   good: false
   characters:
@@ -123,6 +136,7 @@ episodes:
   season: 11
   episode: 14
   description: Homer attempts to help when Flanders experiences a tragic loss.
+  disneyplus_id:
   simpsonsworld_id: 288077891629
   good: false
   characters:
@@ -133,6 +147,7 @@ episodes:
   episode: 15
   description: Homer is forced to become a missionary on a remote island after he
     pledges a large sum of money to PBS.
+  disneyplus_id:
   simpsonsworld_id: 310458435665
   good: false
   characters:
@@ -141,6 +156,7 @@ episodes:
   season: 11
   episode: 16
   description: Moe undergoes plastic surgery and becomes a hot new soap opera star.
+  disneyplus_id:
   simpsonsworld_id: 294758467783
   good: false
   characters:
@@ -151,6 +167,7 @@ episodes:
   description: A Native American casino manager shows Bart a glimpse into the future...
     a time when Bart is an over-the-hill moocher and Lisa is President of the United
     States.
+  disneyplus_id:
   simpsonsworld_id: 302835267686
   good: true
   characters:
@@ -162,6 +179,7 @@ episodes:
   description: Barney swears off alcohol, creating a rift between he and Homer; seeking
     to win a contest, Bart and Lisa attempt to photograph a new cover for the Springfield
     phone book.
+  disneyplus_id:
   simpsonsworld_id: 306930755636
   good: false
   characters:
@@ -172,6 +190,7 @@ episodes:
   episode: 19
   description: The Simpsons find themselves on the run from the law after they accidentally
     kill a beloved alligator while vacationing in Florida.
+  disneyplus_id:
   simpsonsworld_id: 292935747924
   good: false
   characters:
@@ -182,6 +201,7 @@ episodes:
   description: After watching a movie about a sexy tango dancer, Lisa enrolls in a
     tap dance class... only to discover she has two left feet; Bart and Milhouse abandon
     a camping trip and hide out in a shopping mall.
+  disneyplus_id:
   simpsonsworld_id: 302849091512
   good: true
   characters:
@@ -193,6 +213,7 @@ episodes:
   episode: 21
   description: When Otto ditches his fiancée at the altar, Bart invites her to stay
     with the family... forcing Marge to compete with the much younger woman.
+  disneyplus_id:
   simpsonsworld_id: 301683779737
   good: true
   characters:
@@ -202,6 +223,7 @@ episodes:
   episode: 22
   description: This 'behind-the-scenes' special chronicles the ups and downs of America's
     favorite sitcom family.
+  disneyplus_id:
   simpsonsworld_id: 279751747780
   good: true
   characters:

--- a/episodes/season_12.yml
+++ b/episodes/season_12.yml
@@ -6,6 +6,7 @@ episodes:
   description: On Halloween... a deceased Homer must perform one good deed to get
     into heaven; angry dolphins launch an attack against the people of Springfield;
     Bart and Lisa encounter characters from fairy tales.
+  disneyplus_id:
   simpsonsworld_id: 294765123660
   good: false
   characters:
@@ -15,6 +16,7 @@ episodes:
   episode: 2
   description: The townspeople of Springfield divide into two communities when the
     telephone company institutes a new area code system.
+  disneyplus_id:
   simpsonsworld_id: 300911171880
   good: true
   characters:
@@ -24,6 +26,7 @@ episodes:
   episode: 3
   description: Krusty discovers that he fathered a child during the Gulf War... only
     to gamble away his daughter's precious violin during a poker game with Fat Tony.
+  disneyplus_id:
   simpsonsworld_id: 306934851515
   good: false
   characters:
@@ -33,6 +36,7 @@ episodes:
   episode: 4
   description: Lisa joins a group of eco-radicals in her attempt to save the city's
     oldest redwood tree.
+  disneyplus_id:
   simpsonsworld_id: 306939971530
   good: false
   characters:
@@ -42,6 +46,7 @@ episodes:
   episode: 5
   description: As the Thanksgiving holiday approaches, Mr. Burns hires Homer to be
     his 'prank monkey.'
+  disneyplus_id:
   simpsonsworld_id: 311670339999
   good: false
   characters:
@@ -52,6 +57,7 @@ episodes:
   episode: 6
   description: Homer uses his new computer to spread gossip on the Internet... and
     eventually finds himself stranded on a mysterious island.
+  disneyplus_id:
   simpsonsworld_id: 302843971598
   good: false
   characters:
@@ -61,6 +67,7 @@ episodes:
   episode: 7
   description: Homer and Bart become scam artists when the family is faced with the
     cost of a sudden car repair.
+  disneyplus_id:
   simpsonsworld_id: 304456259863
   good: true
   characters:
@@ -72,6 +79,7 @@ episodes:
   description: As Christmas approaches, a winter snowstorm traps Bart, Lisa and their
     fellow students inside Springfield Elementary, where Principal Skinner attempts
     to keep chaos from erupting.
+  disneyplus_id:
   simpsonsworld_id: 307850819951
   good: false
   characters:
@@ -83,6 +91,7 @@ episodes:
   episode: 9
   description: Homer experiences a dramatic increase in intelligence when researchers
     remove a crayon lodged in his brain.
+  disneyplus_id:
   simpsonsworld_id: 306945603638
   good: true
   characters:
@@ -94,6 +103,7 @@ episodes:
   description: With Marge's help, an inmate with artistic ability is paroled from
     prison.  But when the ex-con gets a job painting a mural at the elementary school,
     he clashes with Skinner.
+  disneyplus_id:
   simpsonsworld_id: 302844995961
   good: false
   characters:
@@ -104,6 +114,7 @@ episodes:
   episode: 11
   description: When the Comic Book Guy suffers a heart attack, Bart and Milhouse take
     over his store.
+  disneyplus_id:
   simpsonsworld_id: 310459971509
   good: true
   characters:
@@ -115,6 +126,7 @@ episodes:
   episode: 12
   description: When the Simpsons construct a tennis court in the backyard, Bart pairs
     up with Marge and becomes a tennis whiz... much to Homer's disappointment.
+  disneyplus_id:
   simpsonsworld_id: 300916291603
   good: false
   characters:
@@ -126,6 +138,7 @@ episodes:
   episode: 13
   description: Sideshow Bob wins release from prison and hypnotizes Bart to kill Krusty
     the Clown.
+  disneyplus_id:
   simpsonsworld_id: 307106883649
   good: false
   characters:
@@ -137,6 +150,7 @@ episodes:
   episode: 14
   description: After casting Bart and his friends as singers in an all-boy band, a
     crazed record producer launches an attack on the offices of MAD magazine.
+  disneyplus_id:
   simpsonsworld_id: 310437443723
   good: true
   characters:
@@ -146,6 +160,7 @@ episodes:
   episode: 15
   description: Homer goes on a hunger strike after learning that the owner of the
     Springfield Isotopes plans on moving the team to Albuquerque.
+  disneyplus_id:
   simpsonsworld_id: 307850819931
   good: true
   characters:
@@ -155,6 +170,7 @@ episodes:
   episode: 16
   description: Lisa searches for answers when a new student at school bullies her;
     Homer starts his own baby-proofing business.
+  disneyplus_id:
   simpsonsworld_id: 302846019892
   good: false
   characters:
@@ -165,6 +181,7 @@ episodes:
   episode: 17
   description: The Simpsons journey through Africa, where they encounter jungle animals,
     tribesmen... and a chimp refuge owner with a secret.
+  disneyplus_id:
   simpsonsworld_id: 302845507908
   good: false
   characters:
@@ -175,6 +192,7 @@ episodes:
   description: 'A day in the life of the Simpsons replays three times: Homer panics
     when Marge slices off his thumb; Lisa attempts to place her entry in the school
     science fair; Bart is pursued by gangsters.'
+  disneyplus_id:
   simpsonsworld_id: 302842947994
   good: false
   characters:
@@ -186,6 +204,7 @@ episodes:
   description: To fulfill his dead wife's final wish, Ned Flanders converts an old,
     closed amusement park into a new Christian amusement park, 'Praiseland.'  The
     park flops until visitors begin having 'visions.'
+  disneyplus_id:
   simpsonsworld_id: 302848579632
   good: true
   characters:
@@ -196,6 +215,7 @@ episodes:
   description: After Homer injures his knee, he's housebound for recuperation.  A
     successful stint as a babysitter prompts Homer to open a full-time daycare service,
     leaving Bart and Lisa feeling neglected.
+  disneyplus_id:
   simpsonsworld_id: 301652547508
   good: false
   characters:
@@ -205,6 +225,7 @@ episodes:
   episode: 21
   description: The Simpsons jump a train, and meet a hobo, who tells them twisted
     versions of three classic tales, all of which feature Simpsons characters.
+  disneyplus_id:
   simpsonsworld_id: 301685315594
   good: false
   characters:

--- a/episodes/season_13.yml
+++ b/episodes/season_13.yml
@@ -6,6 +6,7 @@ episodes:
   description: On Halloween, the Simpsons are menaced by a computer controlling an
     automated house; a gypsy curses Homer; Lisa and Bart find themselves in a Harry
     Potter-like adventure.
+  disneyplus_id:
   simpsonsworld_id: 307115075729
   good: false
   characters:
@@ -16,6 +17,7 @@ episodes:
   description: A stern judge rules that Homer and Bart are to be tethered together,
     and later, Homer and Marge are declared bad parents and placed in old-fashioned
     wooden stocks.
+  disneyplus_id:
   simpsonsworld_id: 307116099877
   good: false
   characters:
@@ -24,6 +26,7 @@ episodes:
   episode: 3
   description: Moe turns the bar into a pretentious hang-out for Springfield's 'beautiful
     people,' forcing Homer to start a bar of his own inside his garage.
+  disneyplus_id:
   simpsonsworld_id: 300917827935
   good: false
   characters:
@@ -34,6 +37,7 @@ episodes:
   episode: 4
   description: When Mr. Burns falls for an attractive traffic cop many years his junior,
     he enlists Homer's help in romancing her.
+  disneyplus_id:
   simpsonsworld_id: 301344323882
   good: false
   characters:
@@ -44,6 +48,7 @@ episodes:
   episode: 5
   description: When placed under hypnosis, Homer struggles with a repressed memory-which
     leads to a shocking discovery.
+  disneyplus_id:
   simpsonsworld_id: 302898755902
   good: false
   characters:
@@ -53,6 +58,7 @@ episodes:
   episode: 6
   description: As Christmas approaches... Lisa searches for a new religion after Mr.
     Burns takes over her church and runs it like a corporation.
+  disneyplus_id:
   simpsonsworld_id: 288120899968
   good: true
   characters:
@@ -62,6 +68,7 @@ episodes:
   episode: 7
   description: A social worker attempts to transform the family into a functional,
     cooperative unit... until Homer's other wife shows up unexpectedly.
+  disneyplus_id:
   simpsonsworld_id: 283083843778
   good: false
   characters:
@@ -72,6 +79,7 @@ episodes:
   episode: 8
   description: After Springfield wins the title of World's Fattest Town, Marge launches
     an anti-sugar crusade, and sugar is banned from the city.
+  disneyplus_id:
   simpsonsworld_id: 302893635523
   good: false
   characters:
@@ -81,6 +89,7 @@ episodes:
   episode: 9
   description: When Homer has to have his jaw wired shut, he discovers the joys of
     listening, but Marge finds that a well-behaved Homer isn't what she really wanted.
+  disneyplus_id:
   simpsonsworld_id: 310440003514
   good: true
   characters:
@@ -92,6 +101,7 @@ episodes:
   description: Marge's ex-boyfriend, now one of the world's richest men, offers Homer
     a million dollars in exchange for a weekend with her, to see what 'might have
     been.'
+  disneyplus_id:
   simpsonsworld_id: 301684803770
   good: false
   characters:
@@ -102,6 +112,7 @@ episodes:
   episode: 11
   description: Bart travels to Canada to win back the heart of Rainier Wolfcastle's
     daughter after she runs off with Milhouse.
+  disneyplus_id:
   simpsonsworld_id: 307122755675
   good: false
   characters:
@@ -112,6 +123,7 @@ episodes:
   episode: 12
   description: Bart befriends an aging movie cowboy who begins drinking heavily when
     asked to appear on Krusty's television show.
+  disneyplus_id:
   simpsonsworld_id: 302899267542
   good: false
   characters:
@@ -122,6 +134,7 @@ episodes:
   description: In an effort to win a date with a beautiful new resident at the nursing
     home, Grampa gets his driver's license back... and gives chase when the object
     of his affection leaves for Branson, Missouri.
+  disneyplus_id:
   simpsonsworld_id: 301659203973
   good: false
   characters:
@@ -132,6 +145,7 @@ episodes:
   description: 'The Simpsons appear as characters in three classic tales: Homer as
     Odysseus leads the Greek army; Bart as Hamlet attempts to avenge the death of
     his father; Lisa as Joan of Arc pits the French against the English.'
+  disneyplus_id:
   simpsonsworld_id: 310411843752
   good: false
   characters:
@@ -141,6 +155,7 @@ episodes:
   episode: 15
   description: When the Simpsons fly to Brazil to locate a missing orphan that Lisa
     has been sponsoring, Homer ends up getting kidnapped.
+  disneyplus_id:
   simpsonsworld_id: 301665347899
   good: false
   characters:
@@ -151,6 +166,7 @@ episodes:
   description: When Homer is attacked by crows, he's prescribed medical marijuana
     to help relieve the pain... leading Burns to promote his happy employee to executive
     vice president of the power plant.
+  disneyplus_id:
   simpsonsworld_id: 310448195762
   good: true
   characters:
@@ -162,6 +178,7 @@ episodes:
   description: Homer is roasted at the Springfield Friar's Club, leading to recollections
     from the past.  But the fate of the Earth hangs in the balance when aliens Kang
     and Kodos make an unexpected appearance.
+  disneyplus_id:
   simpsonsworld_id: 302888515845
   good: false
   characters:
@@ -171,6 +188,7 @@ episodes:
   episode: 18
   description: Bart launches a comic book with an angry Homer as the main character,
     and when it proves a huge success, Homer vows to give up getting angry for Lent.
+  disneyplus_id:
   simpsonsworld_id: 302883907921
   good: true
   characters:
@@ -181,6 +199,7 @@ episodes:
   episode: 19
   description: When Manjula kicks Apu out of the house for cheating on her, Homer
     and Marge search for a way to reunite the couple.
+  disneyplus_id:
   simpsonsworld_id: 288131139601
   good: false
   characters:
@@ -191,6 +210,7 @@ episodes:
   episode: 20
   description: Lisa is overjoyed when she befriends some college students; Bart becomes
     a boy-in-a-plastic-bubble after he's bitten by a Chinese mosquito.
+  disneyplus_id:
   simpsonsworld_id: 310416963509
   good: false
   characters:
@@ -200,6 +220,7 @@ episodes:
   episode: 21
   description: Homer and Marge become murder suspects after an elderly shut-in the
     couple befriended is found dead.
+  disneyplus_id:
   simpsonsworld_id: 301664323751
   good: true
   characters:
@@ -210,6 +231,7 @@ episodes:
   episode: 22
   description: When Wiggum and his men prove ineffective in controlling a citywide
     riot, townspeople begin to feel unsafe... until Homer forms his own police force.
+  disneyplus_id:
   simpsonsworld_id: 302880835773
   good: true
   characters:

--- a/episodes/season_14.yml
+++ b/episodes/season_14.yml
@@ -6,6 +6,7 @@ episodes:
   description: On Halloween, Homer's evil hammock produces an army of Homer clones;
     zombie cowboys threaten to destroy Springfield after Lisa outlaws guns; the Simpsons
     travel to an island inhabited by 'manimals.'
+  disneyplus_id:
   simpsonsworld_id: 221301315863
   good: true
   characters:
@@ -16,6 +17,7 @@ episodes:
   description: When a hidden camera tapes Homer lamenting that having a family meant
     kissing goodbye his dreams of becoming a rock 'n' roll star, Marge enrolls him
     a fantasy rock star camp run by The Rolling Stones.
+  disneyplus_id:
   simpsonsworld_id: 221293123693
   good: false
   characters:
@@ -25,6 +27,7 @@ episodes:
   episode: 3
   description: Bart and Lisa are horrified when they both end up in the same 3rd grade
     class.
+  disneyplus_id:
   simpsonsworld_id: 221347395722
   good: true
   characters:
@@ -34,6 +37,7 @@ episodes:
   description: Marge's life changes dramatically when her attempt to lose weight via
     surgery resulting in larger breasts; Bart and Milhouse get into mischief that
     leads to a public relations nightmare for Krusty.
+  disneyplus_id:
   simpsonsworld_id: 221352515586
   good: false
   characters:
@@ -47,6 +51,7 @@ episodes:
   description: When the Simpson house undergoes fumigation, the family is forced to
     seek shelter elsewhere... and ends up participating in a reality TV program set
     in a house from the 1800s.
+  disneyplus_id:
   simpsonsworld_id: 221388355650
   good: false
   characters:
@@ -56,6 +61,7 @@ episodes:
   episode: 6
   description: When someone attempts to murder Homer, Sideshow Bob is released from
     prison to help identify the culprit before he strikes again.
+  disneyplus_id:
   simpsonsworld_id: 221467203550
   good: false
   characters:
@@ -67,6 +73,7 @@ episodes:
   description: When Bart gets Mrs. Krabappel nominated for Teacher of the Year, the
     family heads for Orlando to attend the ceremony.  But Skinner fears he may lose
     Krabappel forever... and asks Bart to sabotage the affair.
+  disneyplus_id:
   simpsonsworld_id: 221467715532
   good: true
   characters:
@@ -77,6 +84,7 @@ episodes:
   episode: 8
   description: Homer hires a shady private investigator to spy on Lisa when he realizes
     he doesn't know very much about his daughter.
+  disneyplus_id:
   simpsonsworld_id: 221531715548
   good: true
   characters:
@@ -87,6 +95,7 @@ episodes:
   episode: 9
   description: When Marge is mugged at the Kwik-E-Mart, she develops agoraphobia and
     ends up living in the basement... until she turns into a fearless bodybuilder.
+  disneyplus_id:
   simpsonsworld_id: 221532739689
   good: false
   characters:
@@ -97,6 +106,7 @@ episodes:
   description: Inspired by Ned Flanders, Homer turns to prayer in hopes of changing
     his lot in life.  But when he injures himself coming out of church, Homer sues
     for damages... and is awarded the church itself.
+  disneyplus_id:
   simpsonsworld_id: 221526595805
   good: false
   characters:
@@ -107,6 +117,7 @@ episodes:
   description: When Bart discovers the existence of an embarrassing TV commercial
     he appeared in as a baby-and that Homer spent the money he earned-he sues for
     emancipation and moves out of the house.
+  disneyplus_id:
   simpsonsworld_id: 221696067841
   good: false
   characters:
@@ -118,6 +129,7 @@ episodes:
   description: When Lisa becomes a finalist in a spelling bee, she's offered a college
     scholarship in exchange for losing; Homer falls hopelessly in love with Krustyburger's
     limited-time-only rib sandwich.
+  disneyplus_id:
   simpsonsworld_id: 221698627830
   good: false
   characters:
@@ -129,6 +141,7 @@ episodes:
   description: A Hollywood movie star takes a romantic interest in Ned Flanders, and
     when the relationship blossoms, Ned's faith is put to the test when the star wants
     to have premarital sex.
+  disneyplus_id:
   simpsonsworld_id: 221695043703
   good: false
   characters:
@@ -139,6 +152,7 @@ episodes:
   description: When Springfield Airport changes the flight paths of airplanes, sending
     them over the Simpson's house, the family convinces Krusty to run for congress
     so he can change the law.
+  disneyplus_id:
   simpsonsworld_id: 221699651686
   good: true
   characters:
@@ -150,6 +164,7 @@ episodes:
   description: On Valentine's Day, Homer attends a college course on how to succeed
     in the corporate world, he becomes the owner of the power plant and fires Mr.
     Burns... only to realize that running the plant means being away from family.
+  disneyplus_id:
   simpsonsworld_id: 221696067982
   good: true
   characters:
@@ -161,6 +176,7 @@ episodes:
   description: As a British filmmaker makes a documentary about Springfield Elementary,
     Lisa tires to save the nighttime sky from light pollution, while Bart attempts
     to restore his coolness by obtaining a hood ornament from Fat Tony's car.
+  disneyplus_id:
   simpsonsworld_id: 221700675635
   good: false
   characters:
@@ -171,6 +187,7 @@ episodes:
   episode: 17
   description: Homer moves in with a gay couple after discovering a letter Marge wrote
     years earlier that implies she resents him.
+  disneyplus_id:
   simpsonsworld_id: 221699139984
   good: false
   characters:
@@ -182,6 +199,7 @@ episodes:
   description: While vacationing at a dude ranch, Lisa falls for a cute 13-year-old
     cowboy; Homer vows to stop beavers who've dammed a river and kept Native Americans
     from their land.
+  disneyplus_id:
   simpsonsworld_id: 221700163549
   good: false
   characters:
@@ -192,6 +210,7 @@ episodes:
   episode: 19
   description: When Santa's Little Helper becomes Duff Beer's new, highly-paid mascot,
     his original owner comes out of the woodwork and claims the dog belongs to him.
+  disneyplus_id:
   simpsonsworld_id: 221701187546
   good: false
   characters:
@@ -202,6 +221,7 @@ episodes:
   description: When Homer loses his driver's license, he embraces walking.  But Marge
     begins to suffer from stress when the pressure of being the only full-time driver
     in the house takes its toll-and ends up running Homer over in her car.
+  disneyplus_id:
   simpsonsworld_id: 229724227970
   good: false
   characters:
@@ -213,6 +233,7 @@ episodes:
   description: After police discover Bart and Milhouse ransacking Flanders' Beatles
     memorabilia, Marge decides to place her son in a supervised activity, the Pre-Teen
     Braves.
+  disneyplus_id:
   simpsonsworld_id: 229731395601
   good: false
   characters:
@@ -223,6 +244,7 @@ episodes:
   description: When Moe saves baby Maggie's life, a close bond forms.  But when Maggie
     wanders off with some gangsters, Homer and Marge mistakenly believe that Moe is
     responsible for the baby's disappearance.
+  disneyplus_id:
   simpsonsworld_id: 228412483812
   good: true
   characters:

--- a/episodes/season_15.yml
+++ b/episodes/season_15.yml
@@ -6,6 +6,7 @@ episodes:
   description: On Halloween, Homer takes over for the Grim Reaper and discovers Marge's
     name on his list; Professor Frink reanimates his father's corpse; Bart and Milhouse
     play pranks with a watch that can stop time.
+  disneyplus_id:
   simpsonsworld_id: 227335747784
   good: true
   characters:
@@ -16,6 +17,7 @@ episodes:
   description: Mother Simpson is captured by police and placed on trial for sabotaging
     Mr. Burns' germ warfare plant in the 1960s.  Homer's heartfelt testimony helps
     win her release... but Mr. Burns concocts a plot to get revenge.
+  disneyplus_id:
   simpsonsworld_id: 227339843917
   good: true
   characters:
@@ -28,6 +30,7 @@ episodes:
   description: When Lisa is elected student body president, she vows to make the school
     a better place to learn.  But Skinner tricks her into cutting well-liked programs...
     prompting Lisa to call a general student strike.
+  disneyplus_id:
   simpsonsworld_id: 227348035643
   good: false
   characters:
@@ -38,6 +41,7 @@ episodes:
   episode: 4
   description: The Simpsons travel to England, where Homer is imprisoned in the Tower
     of London after he smashes a car into the Queen's royal coach.
+  disneyplus_id:
   simpsonsworld_id: 227349059824
   good: false
   characters:
@@ -48,6 +52,7 @@ episodes:
   description: Homer becomes the laughing stock of the town when a wild bear humiliates
     him.  But when he seeks a rematch, Homer bonds with the animal and tries to save
     its life.
+  disneyplus_id:
   simpsonsworld_id: 227355715580
   good: false
   characters:
@@ -58,6 +63,7 @@ episodes:
   description: When Krusty takes the Sabbath off so he can study for his bar mitzvah,
     he chooses Homer as temporary guest host.  But when Homer's career unexpectedly
     takes off, Krusty finds himself out of a job.
+  disneyplus_id:
   simpsonsworld_id: 227360323557
   good: false
   characters:
@@ -69,6 +75,7 @@ episodes:
   description: As Christmas approaches, Homer discovers the true meaning of the season
     after watching an animated version of A Christmas Carol on television.  But Flanders
     find it impossible to live as the second-nicest-guy in town.
+  disneyplus_id:
   simpsonsworld_id: 227364931670
   good: false
   characters:
@@ -79,6 +86,7 @@ episodes:
   episode: 8
   description: Marge opposes a political group made up of childless people who've
     grown fed-up with accommodating people with families.
+  disneyplus_id:
   simpsonsworld_id: 227369027832
   good: false
   characters:
@@ -89,6 +97,7 @@ episodes:
   description: Homer builds a fighting robot for Bart, but finds he must hide inside
     the device to make it work; Lisa searches for a replacement for Snowball II when
     the cat is run over by a car.
+  disneyplus_id:
   simpsonsworld_id: 227376707538
   good: false
   characters:
@@ -100,6 +109,7 @@ episodes:
   episode: 10
   description: Homer buys an ambulance and starts responding to medical emergencies;
     Marge authors her own romance novel.
+  disneyplus_id:
   simpsonsworld_id: 227378755925
   good: true
   characters:
@@ -111,6 +121,7 @@ episodes:
   description: 'Marge tells the children three historical tales: the story of King
     Henry the Eighth and his quest for a son; Sacagawea''s journey with Lewis and
     Clark; and the rivalry between Mozart and Salieri.'
+  disneyplus_id:
   simpsonsworld_id: 227386947567
   good: false
   characters:
@@ -120,6 +131,7 @@ episodes:
   episode: 12
   description: When Milhouse and his mother relocate to Capital City, Bart strikes
     up a friendship with Lisa; Homer makes money by pretending to be a transient.
+  disneyplus_id:
   simpsonsworld_id: 227392067706
   good: true
   characters:
@@ -128,6 +140,7 @@ episodes:
   episode: 13
   description: Lisa searches for a new identity when baby Maggie turns out to be smarter
     than her.
+  disneyplus_id:
   simpsonsworld_id: 229331523584
   good: true
   characters:
@@ -137,6 +150,7 @@ episodes:
   episode: 14
   description: Homer becomes the majority shareholder of Artie Ziff's troubled Internet
     company-and ends up being arrested by the Securities and Exchange Commission.
+  disneyplus_id:
   simpsonsworld_id: 227426371786
   good: true
   characters:
@@ -148,6 +162,7 @@ episodes:
   description: When a drunken Homer loses control of his car, he places an unconscious
     Marge in the driver's seat so she'll be blamed for the accident; Lisa and Bart
     complain to the creator of the Cosmic Wars saga about his latest films.
+  disneyplus_id:
   simpsonsworld_id: 227399235673
   good: false
   characters:
@@ -158,6 +173,7 @@ episodes:
   episode: 16
   description: Bart's latest prank lands him in juvenile prison, where a tough girl
     forces him to go on the lam.
+  disneyplus_id:
   simpsonsworld_id: 227402307606
   good: true
   characters:
@@ -167,6 +183,7 @@ episodes:
   episode: 17
   description: Mrs. Krabappel dumps Principal Skinner at the altar and has a passionate
     affair with the Comic Book Guy.
+  disneyplus_id:
   simpsonsworld_id: 227423299561
   good: false
   characters:
@@ -178,6 +195,7 @@ episodes:
   episode: 18
   description: Bart and Lisa pursue Homer and Marge after they sneak away on a second
     honeymoon; Grampa catches the eye of a dashing Cuban man.
+  disneyplus_id:
   simpsonsworld_id: 227415619717
   good: false
   characters:
@@ -187,6 +205,7 @@ episodes:
   episode: 19
   description: Homer confronts evildoers in the form of his crime-fighting alter ego,
     the Pie Man-until Mr. Burns blackmails him into throwing a pie at the Dalai Lama.
+  disneyplus_id:
   simpsonsworld_id: 227327555884
   good: false
   characters:
@@ -198,6 +217,7 @@ episodes:
   description: Homer reveals that Marge wasn't the first girl he ever kissed, but
     as he and Marge recount their versions of time spent at a summer camp, Homer realizes
     he caused Marge thirty years of heartbreak.
+  disneyplus_id:
   simpsonsworld_id: 227330115859
   good: false
   characters:
@@ -208,6 +228,7 @@ episodes:
   episode: 21
   description: The Simpsons are thrown in prison after Bart accidentally moons the
     American flag.
+  disneyplus_id:
   simpsonsworld_id: 227410499679
   good: false
   characters:
@@ -218,6 +239,7 @@ episodes:
   description: Mr. Burns buys up all the media outlets in Springfield in an effort
     to polish his image, but soon finds himself at odds with Lisa, who started publishing
     her own newspaper.
+  disneyplus_id:
   simpsonsworld_id: 227405379707
   good: true
   characters:

--- a/episodes/season_16.yml
+++ b/episodes/season_16.yml
@@ -6,6 +6,7 @@ episodes:
   description: On Halloween... Flanders can predict when people will die; in Victorian
     London, Lisa and Bart hunt for a killer; the Simpsons take a fantastic voyage
     after Mr. Burns swallows a miniaturized Maggie.
+  disneyplus_id:
   simpsonsworld_id: 256741955834
   good: true
   characters:
@@ -16,6 +17,7 @@ episodes:
   description: Marge enters a bakeoff competition, but ends up sabotaging the other
     entries; Bart decides to live the life of a swinger after discovering Playdude
     magazine.
+  disneyplus_id:
   simpsonsworld_id: 257840195722
   good: false
   characters:
@@ -27,6 +29,7 @@ episodes:
   description: Lisa becomes self-conscious about her weight after kids at school make
     fun of her posterior;  Marge takes bully Nelson Muntz under her wing ... much
     to Bart's horror.
+  disneyplus_id:
   simpsonsworld_id: 256764995911
   good: false
   characters:
@@ -40,6 +43,7 @@ episodes:
   description: Marge wonders if she made the right choices in life after she encounters
     a successful high school classmate who has traveled the world as a television
     news reporter.
+  disneyplus_id:
   simpsonsworld_id: 256753731544
   good: maybe
   characters:
@@ -48,6 +52,7 @@ episodes:
   episode: 5
   description: Homer builds a nuclear reactor for Lisa's science project; Bart makes
     money creating his own line of t-shirts.
+  disneyplus_id:
   simpsonsworld_id: 256759363799
   good: false
   characters:
@@ -59,6 +64,7 @@ episodes:
   episode: 6
   description: Homer and Grampa smuggle drugs out of Canada after Mr. Burns terminates
     his company's employee prescription drug program.
+  disneyplus_id:
   simpsonsworld_id: 1094235715818
   good: maybe
   characters:
@@ -68,6 +74,7 @@ episodes:
   description: Homer mortgages his house to save Moe's bar, but Marge ends up taking
     control of the business and spends so much time with Moe that Homer fears his
     marriage is in trouble.
+  disneyplus_id:
   simpsonsworld_id: 256807491582
   good: maybe
   characters:
@@ -77,6 +84,7 @@ episodes:
   description: After teaching famous athletes some victory dance moves, Homer is chosen
     to produce the Super Bowl half-time show; Flanders makes a movie featuring violent
     reenactments of biblical events.
+  disneyplus_id:
   simpsonsworld_id: 256813635887
   good: maybe
   characters:
@@ -85,6 +93,7 @@ episodes:
   episode: 9
   description: After sneaking off to a rap concert, Bart fakes his own kidnapping
     and inadvertently implicates Milhouse's father in the 'crime.'
+  disneyplus_id:
   simpsonsworld_id: 256798275935
   good: maybe
   characters:
@@ -94,6 +103,7 @@ episodes:
   description: When tourists shun Springfield, the town legalizes gay marriage in
     hopes of reversing the dire economic slowdown - and Homer makes money by becoming
     an ordained minister.
+  disneyplus_id:
   simpsonsworld_id: 256822339660
   good: maybe
   characters:
@@ -102,6 +112,7 @@ episodes:
   episode: 11
   description: After Bart torments his sister during a school field trip, Lisa gets
     a restraining order; Homer takes a job as a greeter at a local mega-store.
+  disneyplus_id:
   simpsonsworld_id: 256825923849
   good: maybe
   characters:
@@ -110,6 +121,7 @@ episodes:
   episode: 12
   description: Homer pretends to be Selma's husband when Selma travels to China to
     adopt a baby.
+  disneyplus_id:
   simpsonsworld_id: 264432707575
   good: maybe
   characters:
@@ -118,6 +130,7 @@ episodes:
   episode: 13
   description: Bart and Lisa attempt to save Homer and Marge's marriage after Homer
     spends the family's savings on a recreational vehicle.
+  disneyplus_id:
   simpsonsworld_id: 264432707841
   good: maybe
   characters:
@@ -126,6 +139,7 @@ episodes:
   episode: 14
   description: Homer becomes a prison snitch after he's convicted of breaking an outdated
     law; Lisa and Bart discover that Snowball II has a secret life.
+  disneyplus_id:
   simpsonsworld_id: 260844611804
   good: maybe
   characters:
@@ -135,6 +149,7 @@ episodes:
   description: Using Professor Frink's astrological projection machine, Bart and Lisa
     peer into the future, where Bart breaks Lisa's heart by taking away her scholarship
     to Yale.
+  disneyplus_id:
   simpsonsworld_id: 260841027999
   good: maybe
   characters:
@@ -144,6 +159,7 @@ episodes:
   description: Homer ends up in a mental institution after Marge grows convinced the
     contractor he befriended is a figment of his imagination; Marge allows Santa's
     Little Helper to stay at Grampa's retirement home.
+  disneyplus_id:
   simpsonsworld_id: 260835395771
   good: maybe
   characters:
@@ -152,6 +168,7 @@ episodes:
   episode: 17
   description: Bart has a heart attack after he becomes addicted to junk food; the
     Simpsons turn the house into a youth hostel, which is soon overrun by German backpackers.
+  disneyplus_id:
   simpsonsworld_id: 264207427808
   good: maybe
   characters:
@@ -160,6 +177,7 @@ episodes:
   episode: 18
   description: Homer behaves like a domineering stage mom after Lisa achieves fame
     by appearing in a singing competition on The Krusty the Clown Show.
+  disneyplus_id:
   simpsonsworld_id: 264212035982
   good: maybe
   characters:
@@ -168,6 +186,7 @@ episodes:
   episode: 19
   description: Homer is declared a prophet after he convinces everyone in town that
     the end of the world is at hand.
+  disneyplus_id:
   simpsonsworld_id: 264217155650
   good: false
   characters:
@@ -178,6 +197,7 @@ episodes:
   description: Flanders feels like a fool after sorority girls run an adult Web site
     from his house without his knowledge, so he and the boys move away from Springfield...
     to a town where everyone looks like a Hummel figurine.
+  disneyplus_id:
   simpsonsworld_id: 264560707993
   good: maybe
   characters:
@@ -186,6 +206,7 @@ episodes:
   episode: 21
   description: After Bart gets expelled, he's enrolled in Catholic school, where he
     befriends a priest who wants to convert him and Homer to Catholicism.
+  disneyplus_id:
   simpsonsworld_id: 264455235845
   good: maybe
   characters:

--- a/episodes/season_17.yml
+++ b/episodes/season_17.yml
@@ -6,6 +6,7 @@ episodes:
   description: When Homer allows the mob to film a pornographic movie at the house,
     a disgusted Marge leaves the family and hooks up with a doctor trying to save
     the lives of manatees.
+  disneyplus_id:
   simpsonsworld_id: 273502275982
   good: false
   characters:
@@ -16,6 +17,7 @@ episodes:
   episode: 2
   description: Lisa must confront her darkest fears after a cemetery is relocated
     to the Simpsons' neighborhood.
+  disneyplus_id:
   simpsonsworld_id: 277101123962
   good: false
   characters:
@@ -26,6 +28,7 @@ episodes:
   description: After Kirk and Luann rekindle their relationship, Bart and Milhouse
     plot to end the romance... only to inadvertently cause Homer and Marge to break
     up instead.
+  disneyplus_id:
   simpsonsworld_id: 273506371834
   good: false
   characters:
@@ -37,6 +40,7 @@ episodes:
   description: On Halloween, Bart is replaced by a robotic boy after he falls into
     a coma; Burns hunts down Homer in a most dangerous game; a witch transforms trick-or-treaters
     into the costumes they're wearing.
+  disneyplus_id:
   simpsonsworld_id: 310466627927
   good: false
   characters:
@@ -46,6 +50,7 @@ episodes:
   episode: 5
   description: After spending time with her son, Marge begins to worry that she's
     turning Bart into a momma's boy; Homer enters an arm-wrestling competition.
+  disneyplus_id:
   simpsonsworld_id: 279766083701
   good: false
   characters:
@@ -56,6 +61,7 @@ episodes:
   episode: 6
   description: After winning popularity as the Safety Salamander, Homer challenges
     Quimby during a special mayoral recall election.
+  disneyplus_id:
   simpsonsworld_id: 273512003506
   good: maybe
   characters:
@@ -64,6 +70,7 @@ episodes:
   episode: 7
   description: A lonely Marge joins a women's group; Milhouse teaches Lisa how to
     speak Italian.
+  disneyplus_id:
   simpsonsworld_id: 279770179721
   good: maybe
   characters:
@@ -72,6 +79,7 @@ episodes:
   episode: 8
   description: The Simpsons travel to Italy to retrieve Mr. Burn's expensive new sports
     car... only to encounter Sideshow Bob and his murderous family.
+  disneyplus_id:
   simpsonsworld_id: 256858691577
   good: maybe
   characters:
@@ -81,6 +89,7 @@ episodes:
   description: 'The Simpsons appear in three Christmas tales: the story of the birth
     of Jesus; a World War II tale featuring Grampa, Mr. Burns and Santa; and a musical
     featuring The Nutcracker suite.'
+  disneyplus_id:
   simpsonsworld_id: 256885315702
   good: maybe
   characters:
@@ -89,6 +98,7 @@ episodes:
   episode: 10
   description: When an old letter is delivered to the Simpson home, Homer comes to
     believe that Grampa isn't his biological father after all.
+  disneyplus_id:
   simpsonsworld_id: 279775811924
   good: maybe
   characters:
@@ -98,6 +108,7 @@ episodes:
   description: After Bart gets into trouble at school, Homer drives Bart to Oregon,
     where he attends a behavior modification camp; Marge becomes a popular drug dealer
     after she sells Homer's pain medications during a yard sale.
+  disneyplus_id:
   simpsonsworld_id: 310483523720
   good: maybe
   characters:
@@ -107,6 +118,7 @@ episodes:
   description: Lisa vows to turn Groundskeeper Willie into a 'proper gentleman' in
     time for the upcoming school science fair; Homer tries to find something to wear
     after he rips his favorite blue pants.
+  disneyplus_id:
   simpsonsworld_id: 307171907536
   good: maybe
   characters:
@@ -116,6 +128,7 @@ episodes:
   description: When the Simpsons become trapped inside a cave, Lisa recounts a story
     involving a bag of gold coins and how it affected the lives of Mr. Burns, Moe
     and Homer.
+  disneyplus_id:
   simpsonsworld_id: 277107267767
   good: maybe
   characters:
@@ -124,6 +137,7 @@ episodes:
   episode: 14
   description: Marge teaches Rod and Todd Flanders how to have fun; a lonely chimpanzee
     grabs hold of Bart.
+  disneyplus_id:
   simpsonsworld_id: 277113411511
   good: maybe
   characters:
@@ -132,6 +146,7 @@ episodes:
   episode: 15
   description: Marge swaps places with a British wife after the Simpsons become contestants
     on a reality television show.
+  disneyplus_id:
   simpsonsworld_id: 277119043544
   good: maybe
   characters:
@@ -140,6 +155,7 @@ episodes:
   episode: 16
   description: After costing Springfield a professional football team, Grampa tries
     to end his life, but the experience changes him, and he ends up becoming a matador.
+  disneyplus_id:
   simpsonsworld_id: 292950083730
   good: maybe
   characters:
@@ -149,6 +165,7 @@ episodes:
   description: Mr. Burns closes the nuclear power plant and outsources all the jobs,
     forcing Homer to relocate to India; MacGyver fans Patty and Selma kidnap actor
     Richard Dean Anderson.
+  disneyplus_id:
   simpsonsworld_id: 283757123904
   good: maybe
   characters:
@@ -157,6 +174,7 @@ episodes:
   episode: 18
   description: 'The Simpsons appear in three stories set at sea: the journey of The
     Mayflower, the mutiny on The Bounty, and the capsizing of a cruise ship.'
+  disneyplus_id:
   simpsonsworld_id: 310489667660
   good: maybe
   characters:
@@ -166,6 +184,7 @@ episodes:
   description: After Skinner is fired for insinuating that girls are inferior to boys
     in math, Springfield Elementary is split into two groups-boys and girls-forcing
     Lisa to dress up like a boy so she can attend a math class.
+  disneyplus_id:
   simpsonsworld_id: 274367043639
   good: maybe
   characters:
@@ -174,6 +193,7 @@ episodes:
   episode: 20
   description: After Marge develops amnesia and can't remember anything about Homer,
     she decides to kick him out of the house and see other people.
+  disneyplus_id:
   simpsonsworld_id: 277125187506
   good: maybe
   characters:
@@ -182,6 +202,7 @@ episodes:
   episode: 21
   description: Lisa protests when Springfield passes a law requiring that creationism
     be taught alongside evolution in public schools.
+  disneyplus_id:
   simpsonsworld_id: 277127235959
   good: maybe
   characters:
@@ -190,6 +211,7 @@ episodes:
   episode: 22
   description: Homer and Marge play marriage counselors to help a baseball player
     and his sexy recording artist-wife.
+  disneyplus_id:
   simpsonsworld_id: 292955203576
   good: false
   characters:

--- a/episodes/season_18.yml
+++ b/episodes/season_18.yml
@@ -6,6 +6,7 @@ episodes:
   description: Lisa befriends the son of mobster Fat Tony, whose dream is to become
     a chef; Homer and Bart take over the 'family business' after Fat Tony is gunned
     down.
+  disneyplus_id:
   simpsonsworld_id: 292959299559
   good: false
   characters:
@@ -18,6 +19,7 @@ episodes:
   episode: 2
   description: Lisa grows jealous after Bart discovers he's a talented jazz drummer;
     Lisa hides some stray animals in the attic.
+  disneyplus_id:
   simpsonsworld_id: 283202115995
   good: false
   characters:
@@ -29,6 +31,7 @@ episodes:
   description: Marge starts her own carpentry business, only to discover that men
     don't trust a woman to do the job; Bart discovers that Skinner is allergic to
     peanuts.
+  disneyplus_id:
   simpsonsworld_id: 283760707876
   good: false
   characters:
@@ -42,6 +45,7 @@ episodes:
   description: 'The Simpsons appear in three tales of horror: Homer turns into a rampaging
     blob; a creature from Jewish folklore does Bart''s bidding; a radio broadcast
     convinces townspeople they''re being invaded by aliens.'
+  disneyplus_id:
   simpsonsworld_id: 302871107984
   good: false
   characters:
@@ -52,6 +56,7 @@ episodes:
   description: After Homer joins the Army, he's selected to play an enemy target during
     war games.  When the Army chases Homer into town, it pits the people of Springfield
     against the military.
+  disneyplus_id:
   simpsonsworld_id: 283080259896
   good: false
   characters:
@@ -61,6 +66,7 @@ episodes:
   episode: 6
   description: Lisa helps Moe get a poem published, but is deeply hurt when Moe refuses
     to acknowledge her contribution.
+  disneyplus_id:
   simpsonsworld_id: 307167299594
   good: false
   characters:
@@ -71,6 +77,7 @@ episodes:
   episode: 7
   description: Homer finds happiness after he buys an ice cream truck; Marge finds
     her purpose in life when she makes sculptures out of popsicle sticks.
+  disneyplus_id:
   simpsonsworld_id: 292941379558
   good: maybe
   characters:
@@ -79,6 +86,7 @@ episodes:
   episode: 8
   description: Bart becomes Nelson's best friend; Homer becomes hooked on one of Lisa's
     fantasy books.
+  disneyplus_id:
   simpsonsworld_id: 279785027791
   good: maybe
   characters:
@@ -87,6 +95,7 @@ episodes:
   episode: 9
   description: During the Christmas holiday, Marge attempts to muster the wherewithal
     to kick down-on-his-luck Gil out of the house.
+  disneyplus_id:
   simpsonsworld_id: 279793731867
   good: maybe
   characters:
@@ -96,6 +105,7 @@ episodes:
   description: Marge returns to an island where she joyfully spent some of her childhood
     summers; Homer is forced to work on a fishing vessel that's threatened by a huge
     storm.
+  disneyplus_id:
   simpsonsworld_id: 283764803572
   good: maybe
   characters:
@@ -105,6 +115,7 @@ episodes:
   description: The Simpsons spin three tales of revenge; Homer appears as the Count
     of Monte Cristo; Milhouse uses a gadget to get even with kids who've picked on
     him; comic hero Bart-Man searches for the villain who killed his parents.
+  disneyplus_id:
   simpsonsworld_id: 283790915851
   good: true
   characters:
@@ -114,6 +125,7 @@ episodes:
   description: As Multicultural Day approaches, Lisa invents her own Native American
     heritage; after saving Springfield from a fire, Bart is rewarded with a driver's
     license-and ends up with a pregnant girlfriend who wants to wed.
+  disneyplus_id:
   simpsonsworld_id: 310462531619
   good: maybe
   characters:
@@ -123,6 +135,7 @@ episodes:
   description: In this spoof of the 'Up' documentaries, a filmmaker chronicles the
     lives of a group of Springfield residents, including Homer, who has seemingly
     made good on his quest to become a millionaire.
+  disneyplus_id:
   simpsonsworld_id: 302876739533
   good: maybe
   characters:
@@ -132,6 +145,7 @@ episodes:
   description: Lisa tutors Cletus's children - until Krusty hires them as a novelty
     act for his television show; Bart sees a female therapist after he's caught frightening
     his classmates with a scary story.
+  disneyplus_id:
   simpsonsworld_id: 307175491532
   good: maybe
   characters:
@@ -140,6 +154,7 @@ episodes:
   episode: 15
   description: Homer is horrified when his father begins dating Selma; Bart and Lisa
     build a fort after acquiring a large quantity of empty cardboard boxes.
+  disneyplus_id:
   simpsonsworld_id: 302868035943
   good: false
   characters:
@@ -153,6 +168,7 @@ episodes:
   episode: 16
   description: Homer tries his hand at making money by photographing celebrities and
     selling the images to the tabloids.
+  disneyplus_id:
   simpsonsworld_id: 292962371807
   good: false
   characters:
@@ -163,6 +179,7 @@ episodes:
   episode: 17
   description: After discovering the Internet, Marge becomes a character in a popular
     online fantasy game; Homer referees Lisa's soccer team.
+  disneyplus_id:
   simpsonsworld_id: 277036099916
   good: maybe
   characters:
@@ -172,6 +189,7 @@ episodes:
   description: Bart becomes the shame of Springfield after a bungle on the playing
     field causes the Isotots to lose a pennant game; Homer and Marge fight Reverend
     Lovejoy and his wife over possession of Homer's mattress.
+  disneyplus_id:
   simpsonsworld_id: 279798851587
   good: maybe
   characters:
@@ -180,6 +198,7 @@ episodes:
   episode: 19
   description: Homer and his friends join the volunteer fire department, only to begin
     stealing from fire victims.
+  disneyplus_id:
   simpsonsworld_id: 310491203943
   good: maybe
   characters:
@@ -188,6 +207,7 @@ episodes:
   episode: 20
   description: When Santa's Little Helper gets a job on the police force, Bart buys
     a python to replace him.
+  disneyplus_id:
   simpsonsworld_id: 302865987860
   good: maybe
   characters:
@@ -197,6 +217,7 @@ episodes:
   description: In this spoof of the television series '24,' Bart attempts to stop
     Jimbo, Dolph and Kearney before they unleash a deadly stink bomb at an upcoming
     school bake sale.
+  disneyplus_id:
   simpsonsworld_id: 292963907577
   good: maybe
   characters:
@@ -205,6 +226,7 @@ episodes:
   episode: 22
   description: Kent Brockman accidentally utters an obscenity during a news broadcast,
     leading to a heavy fine from the FCC - and costing Brockman his job.
+  disneyplus_id:
   simpsonsworld_id: 302859843984
   good: maybe
   characters:

--- a/episodes/season_19.yml
+++ b/episodes/season_19.yml
@@ -5,6 +5,7 @@ episodes:
   episode: 1
   description: Marge hires a life coach to turn Homer around after he becomes convinced
     he's nothing but a loser.
+  disneyplus_id:
   simpsonsworld_id: 292943427892
   good: false
   characters:
@@ -14,6 +15,7 @@ episodes:
   episode: 2
   description: Homer becomes an opera star, only to find himself the target of an
     obsessed fan.
+  disneyplus_id:
   simpsonsworld_id: 350651459856
   good: false
   characters:
@@ -23,6 +25,7 @@ episodes:
   episode: 3
   description: Homer makes enemies when he starts his own tow truck business; Marge
     hires outside help to make Maggie more independent.
+  disneyplus_id:
   simpsonsworld_id: 292968003585
   good: maybe
   characters:
@@ -34,6 +37,7 @@ episodes:
   episode: 4
   description: Marge fears for her safety after breaking a promise to a bank robber
     about visiting him in jail.
+  disneyplus_id:
   simpsonsworld_id: 310455875747
   good: maybe
   characters:
@@ -44,6 +48,7 @@ episodes:
   description: 'In three tales of Halloween terror: Homer and Marge attempt to eliminate
     one another after discovering their secret identities; Bart and Lisa aid Kodos
     the space alien; Flanders uses the seven deadly sins to punish Bart.'
+  disneyplus_id:
   simpsonsworld_id: 302852163741
   good: false
   characters:
@@ -54,6 +59,7 @@ episodes:
   description: When his parents are lost at sea and presumed dead, Milhouse becomes
     cooler than Bart; Homer finds himself in hot water when he can't remember the
     color of Marge's eyes.
+  disneyplus_id:
   simpsonsworld_id: 302855747799
   good: maybe
   characters:
@@ -63,6 +69,7 @@ episodes:
   description: After Marge launches a gym for 'regular women' and becomes a successful
     businessperson, Homer decides to have his stomach stapled so she'll find him more
     attractive.
+  disneyplus_id:
   simpsonsworld_id: 294772803561
   good: maybe
   characters:
@@ -72,6 +79,7 @@ episodes:
   description: After another of his attempts to kill the Simpsons is foiled, Sideshow
     Bob is put on trial.  During the proceedings, Bart accidentally kills his old
     nemesis.
+  disneyplus_id:
   simpsonsworld_id: 310458947589
   good: maybe
   characters:
@@ -81,6 +89,7 @@ episodes:
   description: Homer wakes up from a blackout only to discover that Marge and the
     kids have left him.  Using a variety of methods, he probes his memory to unravel
     the mystery.
+  disneyplus_id:
   simpsonsworld_id: 302847555877
   good: maybe
   characters:
@@ -89,6 +98,7 @@ episodes:
   episode: 10
   description: 'When Springfield becomes the first city in the nation to hold a presidential
     primary, voters to turn the one person they can trust: Ralph Wiggum.'
+  disneyplus_id:
   simpsonsworld_id: 307179075535
   good: maybe
   characters:
@@ -97,6 +107,7 @@ episodes:
   episode: 11
   description: Marge and Homer recount how Marge almost fell in love with a college
     professor during the 1990s.
+  disneyplus_id:
   simpsonsworld_id: 299664963588
   good: maybe
   characters:
@@ -106,6 +117,7 @@ episodes:
   description: 'When Homer and Marge become trapped in a tunnel of love, three Valentine''s
     Day stories unfold: Bonnie and Clyde steal each other''s hearts; a take-off on
     ''Lady and the Tramp''; punk rockers Lisa and Nelson are hooked on sweets.'
+  disneyplus_id:
   simpsonsworld_id: 310471235766
   good: maybe
   characters:
@@ -114,6 +126,7 @@ episodes:
   episode: 13
   description: Bart befriends a new kid at school, unaware that he's a snitch; after
     his car is damaged in an accident, Homer ends up with a fancy loaner.
+  disneyplus_id:
   simpsonsworld_id: 302849603730
   good: maybe
   characters:
@@ -122,6 +135,7 @@ episodes:
   episode: 14
   description: Bart and Lisa think they killed Martin Prince; Marge enlists the help
     of a reality TV show after Homer cheats on his diet.
+  disneyplus_id:
   simpsonsworld_id: 302849091724
   good: maybe
   characters:
@@ -130,6 +144,7 @@ episodes:
   episode: 15
   description: Lisa becomes addicted to secondhand smoke when she joins a ballet academy;
     Homer befriends raccoons who stole his beef jerky.
+  disneyplus_id:
   simpsonsworld_id: 310477379554
   good: maybe
   characters:
@@ -138,6 +153,7 @@ episodes:
   episode: 16
   description: Marge and Homer aid country singer Lurleen Lumpkin by reuniting her
     with her deadbeat father.
+  disneyplus_id:
   simpsonsworld_id: 283768387739
   good: maybe
   characters:
@@ -146,6 +162,7 @@ episodes:
   episode: 17
   description: Bart is overjoyed when the calf he's raising is judged Best in Show
     - until he realizes the animal is going to be slaughtered.
+  disneyplus_id:
   simpsonsworld_id: 302847555768
   good: maybe
   characters:
@@ -155,6 +172,7 @@ episodes:
   description: Lisa's documentary about life with the Simpsons is accepted into Sundance,
     but Lisa's initial elation turns to horror when festival-goers begin humiliating
     her dysfunctional family.
+  disneyplus_id:
   simpsonsworld_id: 283769923976
   good: maybe
   characters:
@@ -163,6 +181,7 @@ episodes:
   episode: 19
   description: When Homer's mother returns to Springfield, she asks Homer for his
     forgiveness.
+  disneyplus_id:
   simpsonsworld_id: 299670083511
   good: maybe
   characters:
@@ -172,6 +191,7 @@ episodes:
   description: Krusty hires Lisa to be his intern, but she's so good at the job, she
     ends up replacing him as host of his show; Bart and Homer discover the world of
     coin collecting.
+  disneyplus_id:
   simpsonsworld_id: 294774851723
   good: maybe
   characters:

--- a/episodes/season_20.yml
+++ b/episodes/season_20.yml
@@ -5,6 +5,7 @@ episodes:
   episode: 1
   description: Homer and Flanders team-up as bounty hunters; Marge makes confections
     for an erotic bakery.
+  disneyplus_id:
   simpsonsworld_id: 311088195682
   good: true
   characters:
@@ -17,6 +18,7 @@ episodes:
   description: When Bart steals actor Denis Leary's cell phone, Marge uses its built-in
     GPS signal to track her son... leading the family to the ancient ruins of Machu
     Picchu.
+  disneyplus_id:
   simpsonsworld_id: 304458307742
   good: false
   characters:
@@ -27,6 +29,7 @@ episodes:
   episode: 3
   description: Bart swaps places with his exact double-unaware that the double's wealthy
     siblings are plotting murder.
+  disneyplus_id:
   simpsonsworld_id: 304460355919
   good: maybe
   characters:
@@ -36,6 +39,7 @@ episodes:
   description: On Halloween... Transformer-like robots duke it out in Springfield;
     Homer kills off celebrities so their likenesses can be exploited; the Simpsons
     appear in a spoof of a 'Peanuts' Halloween special.
+  disneyplus_id:
   simpsonsworld_id: 691895363987
   good: false
   characters:
@@ -46,6 +50,7 @@ episodes:
   description: In a series of flashbacks... Homer and Marge end up in a cabin in the
     woods with newlyweds Flanders and Maude; Homer and Marge's marriage is nearly
     ruined when they meet exciting new people during a party.
+  disneyplus_id:
   simpsonsworld_id: 311675459549
   good: maybe
   characters:
@@ -54,6 +59,7 @@ episodes:
   episode: 6
   description: When Lisa discovers a talent for solving crossword puzzles, she enters
     a crossword tournament-unaware that Homer bet against her.
+  disneyplus_id:
   simpsonsworld_id: 310541891517
   good: false
   characters:
@@ -64,6 +70,7 @@ episodes:
   episode: 7
   description: Homer thinks Bart's new Muslim friend belongs to a family of terrorists;
     Lisa acquires her first iPod-like device.
+  disneyplus_id:
   simpsonsworld_id: 310498883779
   good: maybe
   characters:
@@ -72,6 +79,7 @@ episodes:
   episode: 8
   description: As Lisa tries to find a habitat for endangered bees, Mr. Burns builds
     a state-of-the-art sports arena-which happens to look like a giant hive.
+  disneyplus_id:
   simpsonsworld_id: 310506051725
   good: true
   characters:
@@ -82,6 +90,7 @@ episodes:
   episode: 9
   description: Lisa's new best friend creates a fantasy world so real it threatens
     to drive them apart.
+  disneyplus_id:
   simpsonsworld_id: 292944963870
   good: maybe
   characters:
@@ -91,6 +100,7 @@ episodes:
   description: When Homer discovers that he was almost elected class president in
     high school, an old Italian cook uses a magic pot of tomato sauce to show him
     an alternate version of his life.
+  disneyplus_id:
   simpsonsworld_id: 273728067781
   good: maybe
   characters:
@@ -100,6 +110,7 @@ episodes:
   description: Lisa freezes during a federal school assessment test; Homer tries to
     prevent accidents from happening after he forgets to pay an insurance bill; Skinner
     accompanies Bart and other underachievers on a trip to Capital City.
+  disneyplus_id:
   simpsonsworld_id: 277134915702
   good: maybe
   characters:
@@ -109,6 +120,7 @@ episodes:
   description: When Homer and Marge's adjustable mortgage rate skyrockets, they're
     forced to move out of the house... until Flanders purchases the property and becomes
     their landlord.
+  disneyplus_id:
   simpsonsworld_id: 273029699673
   good: maybe
   characters:
@@ -117,6 +129,7 @@ episodes:
   episode: 13
   description: In this 'National Treasure'-like story... when Maggie disappears at
     a convent, Lisa goes undercover as a nun to solve a mystery involving a rare jewel.
+  disneyplus_id:
   simpsonsworld_id: 273030211958
   good: maybe
   characters:
@@ -125,6 +138,7 @@ episodes:
   episode: 14
   description: The Simpsons travel to Ireland, where Homer and Grampa purchase an
     old pub that's fallen on hard times.
+  disneyplus_id:
   simpsonsworld_id: 307849283838
   good: maybe
   characters:
@@ -134,6 +148,7 @@ episodes:
   description: When their marriage license turns out to be invalid, Homer asks Marge
     to marry him in style.  But when Homer mysteriously disappears just before the
     wedding, Bart and Lisa search for answers.
+  disneyplus_id:
   simpsonsworld_id: 273024579646
   good: maybe
   characters:
@@ -142,6 +157,7 @@ episodes:
   episode: 16
   description: Moe meets a beautiful woman in an Internet chat room who turns out
     to be three feet tall; Homer tries to spend more time with Maggie.
+  disneyplus_id:
   simpsonsworld_id: 273066051746
   good: maybe
   characters:
@@ -151,6 +167,7 @@ episodes:
   description: Bart dumps Milhouse in favor of a cute girl who volunteers her time
     at the retirement home; Lisa is prescribed antidepressants after she reads predictions
     about what Springfield will look like in 50 years.
+  disneyplus_id:
   simpsonsworld_id: 273057347598
   good: maybe
   characters:
@@ -160,6 +177,7 @@ episodes:
   description: As a result of Homer's "helicopter parenting," Lisa employs a trendy
     technique for boosting her popularity, while Bart enters a balsa-wood model-building
     contest; Marge discovers a sauna in the basement.
+  disneyplus_id:
   simpsonsworld_id: 273070659848
   good: maybe
   characters:
@@ -168,6 +186,7 @@ episodes:
   episode: 19
   description: Homer and Marge rent an apartment in tony Waverly Hills so Bart and
     Lisa can attend a better elementary school.
+  disneyplus_id:
   simpsonsworld_id: 299732035764
   good: maybe
   characters:
@@ -176,6 +195,7 @@ episodes:
   episode: 20
   description: 'As Marge and Lisa have their nails done, they spin four tales involving
     famous women: Queen Elizabeth, Snow White, Lady Macbeth and Ayn Rand.'
+  disneyplus_id:
   simpsonsworld_id: 273732163923
   good: maybe
   characters:
@@ -184,6 +204,7 @@ episodes:
   episode: 21
   description: Springfield grapples with an immigration problem when the economy of
     nearby Ogdenville collapses.
+  disneyplus_id:
   simpsonsworld_id: 729848899646
   good: maybe
   characters:

--- a/episodes/season_21.yml
+++ b/episodes/season_21.yml
@@ -5,6 +5,7 @@ episodes:
   episode: 1
   description: Homer ends up with a superhero's physique after he's chosen to appear
     in a film based on a character created by The Comic Book Guy.
+  disneyplus_id:
   simpsonsworld_id: 250297923589
   good: false
   characters:
@@ -16,6 +17,7 @@ episodes:
   description: Principal Skinner fires Mrs. Krabappel after she makes a drunken fool
     of herself at the elementary school - but what Skinner doesn't know is that Bart
     spiked her coffee with alcohol.
+  disneyplus_id:
   simpsonsworld_id: 310517315862
   good: false
   characters:
@@ -26,6 +28,7 @@ episodes:
   episode: 3
   description: Marge vows to drive mixed martial arts from Springfield by defeating
     a fight promoter in the ring.
+  disneyplus_id:
   simpsonsworld_id: 250299971833
   good: false
   characters:
@@ -36,6 +39,7 @@ episodes:
   description: Classic movie monsters are attacked by their spouses; Lisa and Bart
     exchange murders in a Hitchcock spoof; Bart is the key to saving Springfield from
     zombies; Moe's microbrewery mixes beer with Homer's blood.
+  disneyplus_id:
   simpsonsworld_id: 262634051998
   good: false
   characters:
@@ -45,6 +49,7 @@ episodes:
   episode: 5
   description: Homer's life turns into nonstop misery when he becomes Carl's assistant;
     Marge poses for a sexy calendar.
+  disneyplus_id:
   simpsonsworld_id: 250304067959
   good: false
   characters:
@@ -56,6 +61,7 @@ episodes:
   episode: 6
   description: Skinner tells Bart about a former Springfield Elementary student who
     was the best prankster ever; Marge begins shopping at a natural foods store.
+  disneyplus_id:
   simpsonsworld_id: 792414787985
   good: maybe
   characters:
@@ -64,6 +70,7 @@ episodes:
   episode: 7
   description: Lisa befriends a group of Wiccans who are accused of blinding the people
     of Springfield with a spell.
+  disneyplus_id:
   simpsonsworld_id: 250307139830
   good: maybe
   characters:
@@ -72,6 +79,7 @@ episodes:
   episode: 8
   description: Bart attempts to get Homer and Marge pregnant so he can have a brother
     to hang out with.
+  disneyplus_id:
   simpsonsworld_id: 250311235599
   good: maybe
   characters:
@@ -80,6 +88,7 @@ episodes:
   episode: 9
   description: Homer becomes jealous when a reporter takes an interest in Grampa's
     life; Lisa loses a stuffed lamb that Bart brought home from school.
+  disneyplus_id:
   simpsonsworld_id: 250369603964
   good: maybe
   characters:
@@ -88,6 +97,7 @@ episodes:
   episode: 10
   description: Krusty ends up playing second fiddle to Princess Penelope, a new character
     on his show... only to end up falling in love with the actress who plays her.
+  disneyplus_id:
   simpsonsworld_id: 250379331672
   good: maybe
   characters:
@@ -96,6 +106,7 @@ episodes:
   episode: 11
   description: Homer wins a million-dollar lottery but doesn't tell his family the
     news; Lisa stimulates nursing home patients with an interactive Wii-like device.
+  disneyplus_id:
   simpsonsworld_id: 279804995696
   good: maybe
   characters:
@@ -104,6 +115,7 @@ episodes:
   episode: 12
   description: The Simpsons head to the Winter Olympics in Canada after Marge and
     Homer join a curling team; Lisa becomes addicted to collecting Olympic pins.
+  disneyplus_id:
   simpsonsworld_id: 250385475646
   good: maybe
   characters:
@@ -112,6 +124,7 @@ episodes:
   episode: 13
   description: Lisa discovers that her Southern ancestors helped a slave escape to
     freedom.
+  disneyplus_id:
   simpsonsworld_id: 255100483932
   good: maybe
   characters:
@@ -121,6 +134,7 @@ episodes:
   description: Bart creates friction between Marge and Homer so he can get out of
     doing homework.  But when the plot fails, Bart tries to destroy the elementary
     school by reactivating an old Springfield subway line.
+  disneyplus_id:
   simpsonsworld_id: 250390595937
   good: maybe
   characters:
@@ -129,6 +143,7 @@ episodes:
   episode: 15
   description: Bart stirs up trouble when he kisses a girl at school; Lisa's popularity
     soars when she receives a failing grade on a test.
+  disneyplus_id:
   simpsonsworld_id: 250397251688
   good: maybe
   characters:
@@ -138,6 +153,7 @@ episodes:
   description: Flanders attempts to redeem Homer during a Bible study trip to Israel;
     Homer becomes delusional after getting lost in the desert and ends up believing
     he's the Chosen One.
+  disneyplus_id:
   simpsonsworld_id: 279809091713
   good: maybe
   characters:
@@ -147,6 +163,7 @@ episodes:
   description: When Mr. Burns is sent to prison for possessing stolen art, he places
     Smithers in charge of running the nuclear power plant; Bart helps Lisa maintain
     an ant farm.
+  disneyplus_id:
   simpsonsworld_id: 250508867924
   good: maybe
   characters:
@@ -155,6 +172,7 @@ episodes:
   episode: 18
   description: After he's sentenced to perform community service, Homer befriends
     Chief Wiggum; Marge mistakes Bart's love for a Japanese card game for a drug addiction.
+  disneyplus_id:
   simpsonsworld_id: 250515523850
   good: maybe
   characters:
@@ -162,6 +180,7 @@ episodes:
   season: 21
   episode: 19
   description: Lisa comes to the aid of a whale that washes up on Springfield Beach.
+  disneyplus_id:
   simpsonsworld_id: 250519619700
   good: maybe
   characters:
@@ -171,6 +190,7 @@ episodes:
   description: After a bomb squad mistakenly blows up Homer's unattended gym bag,
     releasing radiation into the city, Springfield equips itself with surveillance
     cameras to deter terrorism, allowing Flanders to impose his views on others.
+  disneyplus_id:
   simpsonsworld_id: 250523203904
   good: maybe
   characters:
@@ -179,6 +199,7 @@ episodes:
   episode: 21
   description: As Mother's Day approaches, Homer, Apu and Reverend Lovejoy receive
     a letter from Moe warning that he's going to run away with one of their wives.
+  disneyplus_id:
   simpsonsworld_id: 250592323527
   good: maybe
   characters:
@@ -187,6 +208,7 @@ episodes:
   episode: 22
   description: Bart is convinced that his new neighbor is Sideshow Bob - even though
     the man looks nothing like his arch enemy.
+  disneyplus_id:
   simpsonsworld_id: 250531907855
   good: maybe
   characters:
@@ -196,6 +218,7 @@ episodes:
   description: Moe discovers a talent for judging contests, leading to an appearance
     on the television series 'American Idol;' Homer drives Marge crazy when he begins
     hanging around the house.
+  disneyplus_id:
   simpsonsworld_id: 255074883631
   good: maybe
   characters:

--- a/episodes/season_22.yml
+++ b/episodes/season_22.yml
@@ -5,6 +5,7 @@ episodes:
   episode: 1
   description: Lisa attends a performing arts camp; Krusty stands trial in The Hague
     after being tricked into believing he won the Nobel Prize.
+  disneyplus_id:
   simpsonsworld_id: 263519811935
   good: maybe
   characters:
@@ -14,6 +15,7 @@ episodes:
   description: Lisa donates money to a microfinance bank to help Nelson's custom bicycle
     company; Homer games the system by purchasing expensive items from stores and,
     after using them for a period of time, returns them for a refund.
+  disneyplus_id:
   simpsonsworld_id: 263525955686
   good: maybe
   characters:
@@ -22,6 +24,7 @@ episodes:
   episode: 3
   description: Lisa becomes the coach of Bart's Little League team... and ends up
     firing Bart after he ignores her instructions.
+  disneyplus_id:
   simpsonsworld_id: 263531587720
   good: maybe
   characters:
@@ -31,6 +34,7 @@ episodes:
   description: Bart and Milhouse use their videogame skills to save Springfield; in
     a 'Dead Calm' spoof a vacationing Homer and Marge rescue a stranger who may be
     a murderer; Lisa falls for a hunky vampire in a spoof of 'Twilight'.
+  disneyplus_id:
   simpsonsworld_id: 263577155794
   good: false
   characters:
@@ -41,6 +45,7 @@ episodes:
   description: Lisa decides she doesn't want to end up like Marge; Bart becomes the
     new school bully after Nelson is humiliated by a series of mishaps; Maggie becomes
     obsessed with owning a collectible elf figure.
+  disneyplus_id:
   simpsonsworld_id: 263540291528
   good: maybe
   characters:
@@ -49,6 +54,7 @@ episodes:
   episode: 6
   description: When a dying Mr. Burns loses his memory, the residents of Springfield
     exact revenge on the abusive billionaire by using him as their plaything.
+  disneyplus_id:
   simpsonsworld_id: 263544387571
   good: maybe
   characters:
@@ -57,6 +63,7 @@ episodes:
   episode: 7
   description: The Simpsons decide to give away Santa's Little Helper after the dog
     swallows Bart's beloved carrier pigeon.
+  disneyplus_id:
   simpsonsworld_id: 263545923923
   good: maybe
   characters:
@@ -66,6 +73,7 @@ episodes:
   description: Four Christmas tales... Bart takes a 'Polar Express' ride to ask Santa
     for a dirt bike; Lisa worries after Marge is drafted to fight Nazis; Martha Stewart
     helps spruce-up the house; the family celebrates a Muppet Christmas.
+  disneyplus_id:
   simpsonsworld_id: 263551043814
   good: maybe
   characters:
@@ -74,6 +82,7 @@ episodes:
   episode: 9
   description: Acting as an undercover informant, Homer sets out to win the trust
     of mobster Fat Tony as part of the FBI's efforts to break up his crime syndicate.
+  disneyplus_id:
   simpsonsworld_id: 263572035826
   good: maybe
   characters:
@@ -82,6 +91,7 @@ episodes:
   episode: 10
   description: As Bart tries to determine the origin of a scar on his hand, Marge
     reacquaints herself with three old friends.
+  disneyplus_id:
   simpsonsworld_id: 256848451515
   good: maybe
   characters:
@@ -90,6 +100,7 @@ episodes:
   episode: 11
   description: Smithers convinces Moe to turn his tavern into a gay bar; with Bart's
     help, Skinner romances the elementary school's new music teacher.
+  disneyplus_id:
   simpsonsworld_id: 263579715535
   good: maybe
   characters:
@@ -99,6 +110,7 @@ episodes:
   description: Homer uses plotlines from a 1980's sitcom to deal with Bart when the
     boy grows obsessed with obtaining a cool mini-bike; Bart attempts to trade nuclear
     secrets to the Chinese government.
+  disneyplus_id:
   simpsonsworld_id: 256851523744
   good: maybe
   characters:
@@ -108,6 +120,7 @@ episodes:
   description: Unable to get a date for Valentine's Day, Moe asks Homer to act as
     his 'wingman' and help him attract women; Marge has her entire head of hair dyed
     gray after she discovers her first gray hair.
+  disneyplus_id:
   simpsonsworld_id: 254809667917
   good: maybe
   characters:
@@ -116,6 +129,7 @@ episodes:
   episode: 14
   description: When the 'Angry Dad' character is turned into an award-winning animated
     short film, Homer hogs the spotlight... much to Bart's dismay.
+  disneyplus_id:
   simpsonsworld_id: 254814275630
   good: maybe
   characters:
@@ -125,6 +139,7 @@ episodes:
   description: When Lisa discovers a wildflower that turns scorpions into blissful
     creatures, Homer secretly spikes Grampa's coffee with juice from the plant, turning
     him into a docile old man.
+  disneyplus_id:
   simpsonsworld_id: 254817859928
   good: maybe
   characters:
@@ -134,6 +149,7 @@ episodes:
   description: When legendary comics Cheech and Chong split up, Cheech asks Homer
     to replace his old partner; Marge helps the Cat Lady empty her house of junk...
     only to become a hoarder herself.
+  disneyplus_id:
   simpsonsworld_id: 254821955889
   good: maybe
   characters:
@@ -142,6 +158,7 @@ episodes:
   episode: 17
   description: Homer enrolls in a fathering enrichment class, where he undergoes treatment
     to stop the urge to strangle Bart.
+  disneyplus_id:
   simpsonsworld_id: 254830659539
   good: maybe
   characters:
@@ -150,6 +167,7 @@ episodes:
   episode: 18
   description: Lisa befriends an old magician who shows her how to perform one of
     Houdini's greatest tricks.
+  disneyplus_id:
   simpsonsworld_id: 254866499808
   good: maybe
   characters:
@@ -158,6 +176,7 @@ episodes:
   episode: 19
   description: Fat Tony asks for Selma's hand in marriage; Bart discovers a talent
     for sniffing out truffles.
+  disneyplus_id:
   simpsonsworld_id: 254870083832
   good: maybe
   characters:
@@ -166,6 +185,7 @@ episodes:
   episode: 20
   description: Homer discovers a talent for cutting women's hair; Lisa becomes puzzled
     when a pretty girl at school shows an interest in Milhouse.
+  disneyplus_id:
   simpsonsworld_id: 254876227684
   good: maybe
   characters:
@@ -175,6 +195,7 @@ episodes:
   description: 'A drawer full of old keys sparks several adventures: Homer steals
     the Duff blimp; Bart discovers he can do no wrong; Lisa discovers a strange room
     beneath Springfield Elementary; Marge and Maggie chase a toy train.'
+  disneyplus_id:
   simpsonsworld_id: 254880835816
   good: maybe
   characters:
@@ -183,6 +204,7 @@ episodes:
   episode: 22
   description: Ned Flanders falls for Bart's teacher, Edna Krabappel... but will Krabappel's
     reputation for dating every guy in town spell the end of the relationship?
+  disneyplus_id:
   simpsonsworld_id: 255101507699
   good: maybe
   characters:

--- a/episodes/season_23.yml
+++ b/episodes/season_23.yml
@@ -5,6 +5,7 @@ episodes:
   episode: 1
   description: Homer attempts to help a former CIA agent plagued by violent flashbacks
     from his past.
+  disneyplus_id:
   simpsonsworld_id: 273517123847
   good: false
   characters:
@@ -15,6 +16,7 @@ episodes:
   description: Superintendant Chalmers teaches Bart about Teddy Roosevelt after personally
     taking charge of the boy's education. When Chalmers loses his job, Bart and his
     classmates attempt to get him reinstated.
+  disneyplus_id:
   simpsonsworld_id: 273518659843
   good: true
   characters:
@@ -26,6 +28,7 @@ episodes:
   description: In three terrifying Halloween tales... Homer discovers a unique way
     to communicate with his family; a spoof of 'Dexter' features Homer tricking Flanders;
     a spoof of the movie 'Avatar' features Bart as a tentacled alien.
+  disneyplus_id:
   simpsonsworld_id: 230493251807
   good: false
   characters:
@@ -36,6 +39,7 @@ episodes:
   description: With some help from Martin Prince, Bart constructs cute, baby seal-like
     robots that rival Lisa's entry in a science fair project; Homer ends up working
     for his new assistant.
+  disneyplus_id:
   simpsonsworld_id: 273736771817
   good: false
   characters:
@@ -47,6 +51,7 @@ episodes:
   description: As Homer and Marge vie for the kids' approval... Marge, Bart and Lisa
     become successful food bloggers; Homer finds himself trapped in a meth lab after
     Marge deliberately gives him the wrong address for a restaurant.
+  disneyplus_id:
   simpsonsworld_id: 233194563539
   good: false
   characters:
@@ -57,6 +62,7 @@ episodes:
   description: After Lisa discovers that her favorite author doesn't exist, Homer
     forms a literary gang in hopes of writing a bestselling "tween" novel and raking
     in millions.
+  disneyplus_id:
   simpsonsworld_id: 264559171655
   good: false
   characters:
@@ -67,6 +73,7 @@ episodes:
   episode: 7
   description: Burns appoints Homer the nuclear power plant's new account man, damning
     him to a 'Mad Men'-like existence; Lisa becomes Bart's mentor.
+  disneyplus_id:
   simpsonsworld_id: 1071533123906
   good: false
   characters:
@@ -76,6 +83,7 @@ episodes:
   episode: 8
   description: After being fired from his popular kids' show, Krusty stages a comeback
     with help from an agent who's also an old flame.
+  disneyplus_id:
   simpsonsworld_id: 230516291714
   good: false
   characters:
@@ -86,6 +94,7 @@ episodes:
   description: Thirty years in the future, Bart and Lisa attempt to bond with their
     children on Christmas; an unwed Maggie gives birth while heading home for the
     holidays.
+  disneyplus_id:
   simpsonsworld_id: 230516803889
   good: false
   characters:
@@ -97,6 +106,7 @@ episodes:
   description: Homer becomes a celebrity after he voices his conservative opinions
     on a cable talk show, and attempts to convince leaders of the Republican party
     to nominate singer Ted Nugent for president.
+  disneyplus_id:
   simpsonsworld_id: 230549059731
   good: false
   characters:
@@ -106,6 +116,7 @@ episodes:
   episode: 11
   description: Lisa's idea for an online social network becomes a tremendous hit,
     but so many people become addicted to posting on the site, it leads to chaos.
+  disneyplus_id:
   simpsonsworld_id: 230552131592
   good: false
   characters:
@@ -115,6 +126,7 @@ episodes:
   episode: 12
   description: Moe's bar rag tells the story of his existence; Milhouse tires of taking
     abuse from Bart.
+  disneyplus_id:
   simpsonsworld_id: 230553667901
   good: maybe
   characters:
@@ -124,6 +136,7 @@ episodes:
   description: As Valentine's Day approaches, Marge grows concerned when Lisa finds
     a boyfriend; Bart and Milhouse set out on a 'mythbusting' mission at Springfield
     Elementary.
+  disneyplus_id:
   simpsonsworld_id: 230562371905
   good: maybe
   characters:
@@ -132,6 +145,7 @@ episodes:
   episode: 14
   description: Fed up with the family's negative impact on the city, townspeople banish
     the Simpsons from Springfield.
+  disneyplus_id:
   simpsonsworld_id: 230541891832
   good: maybe
   characters:
@@ -141,6 +155,7 @@ episodes:
   description: Bart becomes a famous street artist after he plasters Springfield with
     unflattering graffiti of Homer's likeness; Apu panics when he's forced to compete
     with a friendly grocery store chain featuring a South Pacific motif.
+  disneyplus_id:
   simpsonsworld_id: 304468035701
   good: maybe
   characters:
@@ -149,6 +164,7 @@ episodes:
   episode: 16
   description: With help from one of Professor Frink's inventions, Marge and the kids
     enter Homer's dreams in hopes of curing him of incontinence.
+  disneyplus_id:
   simpsonsworld_id: 230597187582
   good: maybe
   characters:
@@ -157,6 +173,7 @@ episodes:
   episode: 17
   description: Homer becomes the last human employee at the nuclear power plant after
     Mr. Burns orders a mass firing and replaces staffers with robots.
+  disneyplus_id:
   simpsonsworld_id: 230592067926
   good: maybe
   characters:
@@ -165,6 +182,7 @@ episodes:
   episode: 18
   description: Bart falls for Jimbo's girlfriend Shauna; Homer buys a tricked-out
     treadmill so he can watch old episodes of a 'Lost'-like television show.
+  disneyplus_id:
   simpsonsworld_id: 311189571768
   good: maybe
   characters:
@@ -173,6 +191,7 @@ episodes:
   episode: 19
   description: The Simpsons vacation on a cruise liner, where Bart has so much fun
     he concocts a scheme to keep his family aboard the ship forever.
+  disneyplus_id:
   simpsonsworld_id: 273522243657
   good: maybe
   characters:
@@ -182,6 +201,7 @@ episodes:
   description: After being injured at work, Homer is given eight weeks of paid vacation,
     and decides to keep the news secret from his family; Bart gets Nelson hooked on
     Krustyburgers so he'll gain weight and stop picking on him.
+  disneyplus_id:
   simpsonsworld_id: 230588995967
   good: maybe
   characters:
@@ -190,6 +210,7 @@ episodes:
   episode: 21
   description: Complications ensue when Flanders and Krabappel admit they're secretly
     married.
+  disneyplus_id:
   simpsonsworld_id: 277098051530
   good: maybe
   characters:
@@ -198,6 +219,7 @@ episodes:
   episode: 22
   description: Singer Lady Gaga attempts to cheer Lisa after she's voted the most
     unpopular kid at school.
+  disneyplus_id:
   simpsonsworld_id: 233190467851
   good: maybe
   characters:

--- a/episodes/season_24.yml
+++ b/episodes/season_24.yml
@@ -6,6 +6,7 @@ episodes:
   description: Bart seeks out Cletus's daughter, who has started a new life in New
     York City, Lisa wants to take in a Broadway play but ends up performing Shakespeare
     in Central Park.
+  disneyplus_id:
   simpsonsworld_id: 221691971633
   good: maybe
   characters:
@@ -15,6 +16,7 @@ episodes:
   description: In these three Halloween tales... a black hole threatens to destroy
     Springfield; the Simpsons are terrorized by the unknown in a spoof of 'Paranormal
     Activity'; Bart time travels in a spoof of 'Back to the Future.'
+  disneyplus_id:
   simpsonsworld_id: 221695555645
   good: true
   characters:
@@ -24,6 +26,7 @@ episodes:
   episode: 3
   description: Marge decides she wants to conceive another child; Bart realizes Lisa
     is up to something mysterious and vows to find out what it is.
+  disneyplus_id:
   simpsonsworld_id: 221688899646
   good: maybe
   characters:
@@ -32,6 +35,7 @@ episodes:
   episode: 4
   description: Homer and Marge search for Grampa after he disappears from the retirement
     home; Homer invests Lisa's college fund in an online poker Web site.
+  disneyplus_id:
   simpsonsworld_id: 221688899887
   good: maybe
   characters:
@@ -40,6 +44,7 @@ episodes:
   episode: 5
   description: While serving jury duty, Fat Tony appoints an accountant as his temporary
     Don; an anemic Lisa eats bugs to increase her iron level.
+  disneyplus_id:
   simpsonsworld_id: 221694531617
   good: maybe
   characters:
@@ -49,6 +54,7 @@ episodes:
   description: After his beloved new tablet "MyPad" computer is destroyed, a despondent
     Homer finds solace in a message seemingly written by God - until newsman Kent
     Brockman sets out to debunk the "miracle."
+  disneyplus_id:
   simpsonsworld_id: 229733443727
   good: maybe
   characters:
@@ -57,6 +63,7 @@ episodes:
   episode: 7
   description: Homer is elated when a cool dad and his family move next door, but
     his happiness ends when he realizes he has little in common with his new neighbors.
+  disneyplus_id:
   simpsonsworld_id: 222374467937
   good: maybe
   characters:
@@ -66,6 +73,7 @@ episodes:
   description: When Bart accuses Homer of not liking Santa's Little Helper, Grampa
     recounts the story of how Homer's heart broke after he was forced to give away
     his childhood dog.
+  disneyplus_id:
   simpsonsworld_id: 222491715618
   good: maybe
   characters:
@@ -74,6 +82,7 @@ episodes:
   episode: 9
   description: The Simpsons anticipate the apocalypse after Homer inadvertently triggers
     a shockwave that disables all electronic devices in Springfield.
+  disneyplus_id:
   simpsonsworld_id: 1094312515873
   good: maybe
   characters:
@@ -82,6 +91,7 @@ episodes:
   episode: 10
   description: Bart must pass a district-wide test to save Springfield Elementary;
     Homer uses a discarded parking meter to steal from unsuspecting drivers.
+  disneyplus_id:
   simpsonsworld_id: 222388291945
   good: maybe
   characters:
@@ -90,6 +100,7 @@ episodes:
   episode: 11
   description: After narrowly surviving a tornado, Marge and Homer embark on a search
     for a couple who'll serve as Bart, Lisa and Maggie's legal guardians.
+  disneyplus_id:
   simpsonsworld_id: 257684035668
   good: maybe
   characters:
@@ -98,6 +109,7 @@ episodes:
   episode: 12
   description: Bart attempts to patch things up with his old sweetheart, Mary Spuckler,
     and despite Lisa's input, still manages to sabotage his chances of finding love.
+  disneyplus_id:
   simpsonsworld_id: 257681987573
   good: maybe
   characters:
@@ -106,6 +118,7 @@ episodes:
   episode: 13
   description: With Bart's help, Milhouse transforms into his father; Homer discovers
     a talent for finding things in hidden-picture books.
+  disneyplus_id:
   simpsonsworld_id: 257686595928
   good: maybe
   characters:
@@ -115,6 +128,7 @@ episodes:
   description: With encouragement from Mr. Burns, Grampa revives a famous wrestling
     character from his past whom audiences love to hate, and despite Homer and Marge's
     objections, incorporates Bart into the act.
+  disneyplus_id:
   simpsonsworld_id: 257687107857
   good: maybe
   characters:
@@ -124,6 +138,7 @@ episodes:
   description: When Flanders gives Homer a black eye, he turns to the Bible for answers;
     Lisa is shocked and puzzled when she discovers that a substitute teacher hates
     her.
+  disneyplus_id:
   simpsonsworld_id: 257689667578
   good: maybe
   characters:
@@ -133,6 +148,7 @@ episodes:
   description: Bart stands trial in youth court after he's accused of pulling an Easter
     prank; after buying a comic book collection, Mr. Burns transforms into a 'Batman'-like
     superhero.
+  disneyplus_id:
   simpsonsworld_id: 257714243647
   good: maybe
   characters:
@@ -141,6 +157,7 @@ episodes:
   episode: 17
   description: In an episode that focuses on the choices people make and their outcomes...
     Homer attempts to save his marriage; Milhouse woos Lisa.
+  disneyplus_id:
   simpsonsworld_id: 1094243907551
   good: maybe
   characters:
@@ -149,6 +166,7 @@ episodes:
   episode: 18
   description: Lovejoy quits the church after the Parson appoints a charismatic reverend
     to reinvigorate the parish; Marge tracks down her old wedding dress.
+  disneyplus_id:
   simpsonsworld_id: 257728579751
   good: maybe
   characters:
@@ -158,6 +176,7 @@ episodes:
   description: Moe's new suit catches the attention of venture capitalists, leading
     to the distribution of Moe's own brand of whiskey; Bart cares for Grampa; Lisa
     realizes that her favorite musicians have been turned into holograms.
+  disneyplus_id:
   simpsonsworld_id: 257737283653
   good: maybe
   characters:
@@ -166,6 +185,7 @@ episodes:
   episode: 20
   description: Bart takes piano lessons in hopes of impressing his beautiful young
     teacher; Homer goes completely bald; Marge teaches a Russian man how to drive.
+  disneyplus_id:
   simpsonsworld_id: 257760323921
   good: maybe
   characters:
@@ -174,6 +194,7 @@ episodes:
   episode: 21
   description: Homer, Moe and Lenny travel to Iceland to retrieve lottery winnings
     that Carl ran off with.
+  disneyplus_id:
   simpsonsworld_id: 257753667515
   good: maybe
   characters:
@@ -182,6 +203,7 @@ episodes:
   episode: 22
   description: Homer secretly reconstructs a kiddy train as Marge's anniversary present;
     Marge attracts the attention of a potential paramour online.
+  disneyplus_id:
   simpsonsworld_id: 257768003795
   good: maybe
   characters:

--- a/episodes/season_25.yml
+++ b/episodes/season_25.yml
@@ -6,6 +6,7 @@ episodes:
   description: When Homer returns from a Nuclear Workers Convention and begins behaving
     strangely, Lisa worries that her father has been brainwashed and is now part of
     a terrorist plot to blow up the power plant.
+  disneyplus_id:
   simpsonsworld_id: 307191875741
   good: maybe
   characters:
@@ -15,6 +16,7 @@ episodes:
   description: In three terrifying Halloween tales, Bart, Lisa and Maggie receive
     a visit from The Fat in the Hat; when Bart is decapitated, his head is sewn onto
     Lisa's body; Homer plots to kill Moe at a circus freak show.
+  disneyplus_id:
   simpsonsworld_id: 310259779794
   good: maybe
   characters:
@@ -25,6 +27,7 @@ episodes:
   description: A Springfield funeral prompts Marge, Kent Brockman, Homer and Mr. Burns
     to reexamine a crucial decision in their lives one that has brought them the most
     regret.
+  disneyplus_id:
   simpsonsworld_id: 311688259548
   good: maybe
   characters:
@@ -34,6 +37,7 @@ episodes:
   description: After experiencing a midlife crisis, Homer reaches out to an old pen
     pal; when a cheating scandal rocks Springfield Elementary, Lisa establishes an
     honor code.
+  disneyplus_id:
   simpsonsworld_id: 304473155645
   good: maybe
   characters:
@@ -43,6 +47,7 @@ episodes:
   description: Homer gets trapped in an elevator with a pregnant woman and helps deliver
     her baby; Lisa helps underpaid cheerleaders organize so they can demand a salary
     increase from a greedy football team owner.
+  disneyplus_id:
   simpsonsworld_id: 311105091548
   good: maybe
   characters:
@@ -51,6 +56,7 @@ episodes:
   episode: 6
   description: Lisa is elated to befriend Isabel, a smart new student at school, only
     to realize that she and Isabel are on opposite sides of the political spectrum.
+  disneyplus_id:
   simpsonsworld_id: 310523971648
   good: maybe
   characters:
@@ -60,6 +66,7 @@ episodes:
   description: Bart seeks revenge after Skinner prevents him from attending a school
     field trip aboard a submarine; Lisa suggests to the financially-strapped Krusty
     that he sell the foreign rights to his television show.
+  disneyplus_id:
   simpsonsworld_id: 304476739664
   good: maybe
   characters:
@@ -69,6 +76,7 @@ episodes:
   description: As Christmas approaches, Marge transforms the house into a bed and
     breakfast after Springfield becomes the only town in America to receive snowfall;
     Lisa vows to give her loved ones modest gifts that come from the heart.
+  disneyplus_id:
   simpsonsworld_id: 307199043880
   good: maybe
   characters:
@@ -77,6 +85,7 @@ episodes:
   episode: 9
   description: Homer is put on trial after the FBI catches him illegally downloading
     movies from the Internet.
+  disneyplus_id:
   simpsonsworld_id: 310523459925
   good: maybe
   characters:
@@ -85,6 +94,7 @@ episodes:
   episode: 10
   description: The Comic Book Guy marries a Japanese woman, only to discover that
     the woman's father disapproves of the union.
+  disneyplus_id:
   simpsonsworld_id: 310541379637
   good: maybe
   characters:
@@ -93,6 +103,7 @@ episodes:
   episode: 11
   description: Homer uses augmented reality glasses to spy on Marge; Nelson demands
     a Valentine's Day card from Bart.
+  disneyplus_id:
   simpsonsworld_id: 307204163997
   good: maybe
   characters:
@@ -101,6 +112,7 @@ episodes:
   episode: 12
   description: Bart befriends a fellow student and falconry expert, only to discover
     that the boy suffers from mental illness.
+  disneyplus_id:
   simpsonsworld_id: 310529091639
   good: maybe
   characters:
@@ -109,6 +121,7 @@ episodes:
   episode: 13
   description: Sideshow Bob genetically alters his DNA, giving him superhuman strength;
     Marge volunteers as a teen abstinence counselor.
+  disneyplus_id:
   simpsonsworld_id: 307207235909
   good: maybe
   characters:
@@ -118,6 +131,7 @@ episodes:
   description: When the Simpsons allow members of the retirement community to move
     in with them, Marge worries that Homer is picking up their habits and is turning
     into an old man; a gang of bullies accepts Bart as one of their own.
+  disneyplus_id:
   simpsonsworld_id: 307209283970
   good: maybe
   characters:
@@ -127,6 +141,7 @@ episodes:
   description: Homer convinces Marge to sell a painting that was purchased from Milhouse's
     parents at a yard sale, a painting that turns out to be worth a great deal of
     money.
+  disneyplus_id:
   simpsonsworld_id: 311117891947
   good: maybe
   characters:
@@ -135,6 +150,7 @@ episodes:
   episode: 16
   description: After Lisa delivers a school report on why her father is her hero,
     Homer is tapped to referee World Cup soccer in Brazil.
+  disneyplus_id:
   simpsonsworld_id: 304489539783
   good: maybe
   characters:
@@ -143,6 +159,7 @@ episodes:
   episode: 17
   description: Lisa falls for a competitive eater who subconsciously reminds her of
     Homer; after Bart hides Jailbird from the police, he begins receiving stolen gifts.
+  disneyplus_id:
   simpsonsworld_id: 304500803520
   good: maybe
   characters:
@@ -152,6 +169,7 @@ episodes:
   description: Thirty years in the future, Bart tries to reestablish his relationship
     with his estranged wife, Jenda; Lisa thinks Milhouse is far more interesting after
     he's bitten by a zombie.
+  disneyplus_id:
   simpsonsworld_id: 310257731892
   good: maybe
   characters:
@@ -161,6 +179,7 @@ episodes:
   description: Bart uses voodoo in an attempt to get rid of an art teacher, but when
     the teacher ends up getting pregnant, word spreads that Bart can help couples
     conceive.
+  disneyplus_id:
   simpsonsworld_id: 307214403888
   good: maybe
   characters:
@@ -169,6 +188,7 @@ episodes:
   episode: 20
   description: After Homer bonds with Lisa, Homer's imagination creates a world in
     which everything is made of Lego toys.
+  disneyplus_id:
   simpsonsworld_id: 311243331763
   good: maybe
   characters:
@@ -178,6 +198,7 @@ episodes:
   description: As Mother's Day approaches, after Homer and Marge's attempt to befriend
     other couples fails miserably, Lisa discovers a shocking secret about her new
     best friend.
+  disneyplus_id:
   simpsonsworld_id: 304502851923
   good: maybe
   characters:
@@ -187,6 +208,7 @@ episodes:
   description: Bart is overcome with guilt after an act of cowardice leads to his
     winning a school race; Homer vows to hold his own Fourth of July fireworks display
     after Springfield's holiday celebration is canceled.
+  disneyplus_id:
   simpsonsworld_id: 307219523604
   good: maybe
   characters:
@@ -196,6 +218,7 @@ episodes:
   description: 'A theatrical short that premiered July 13, 2012, attached to the theatrical
     release of Ice Age: Continental Drift.  It was nominated for an Academy Award
     for Best Animated Short.'
+  disneyplus_id:
   simpsonsworld_id: 588949571786
   good: maybe
   characters:

--- a/episodes/season_26.yml
+++ b/episodes/season_26.yml
@@ -4,6 +4,7 @@ episodes:
   season: 26
   episode: 1
   description: 'The unthinkable happens: a Springfield resident dies.'
+  disneyplus_id:
   simpsonsworld_id: 334920771636
   good: false
   characters:
@@ -12,6 +13,7 @@ episodes:
   season: 26
   episode: 2
   description: Homer and Bart set sail on the relation ship.
+  disneyplus_id:
   simpsonsworld_id: 346737219924
   good: false
   characters:
@@ -21,6 +23,7 @@ episodes:
   season: 26
   episode: 3
   description: Marge opens a sandwich shop.
+  disneyplus_id:
   simpsonsworld_id: 340536899599
   good: false
   characters:
@@ -30,6 +33,7 @@ episodes:
   episode: 4
   description: Don't miss the all-new, spooktacular Halloween special, "Treehouse
     of Horror XXV."
+  disneyplus_id:
   simpsonsworld_id: 344255555880
   good: false
   characters:
@@ -39,6 +43,7 @@ episodes:
   episode: 5
   description: An all-new episode featuring guest voice Jane Fonda, whose character
     falls for Mr. Burns.
+  disneyplus_id:
   simpsonsworld_id: 351437379941
   good: false
   characters:
@@ -48,6 +53,7 @@ episodes:
   season: 26
   episode: 6
   description: The Simpsons travel to the 31st century.
+  disneyplus_id:
   simpsonsworld_id: 355593283530
   good: false
   characters:
@@ -57,6 +63,7 @@ episodes:
   episode: 7
   description: Bart faces a tough test at school when he gets a new teacher, Mr. Lassen,
     who vows to crush his spirit.
+  disneyplus_id:
   simpsonsworld_id: 359228483622
   good: false
   characters:
@@ -65,6 +72,7 @@ episodes:
   season: 26
   episode: 8
   description: Homer forms a cover band with some of the other dads in town.
+  disneyplus_id:
   simpsonsworld_id: 362239555757
   good: false
   characters:
@@ -74,6 +82,7 @@ episodes:
   season: 26
   episode: 9
   description: Marge doesn't approve of Homer's Christmas spirits.
+  disneyplus_id:
   simpsonsworld_id: 368212547872
   good: maybe
   characters:
@@ -81,6 +90,7 @@ episodes:
   season: 26
   episode: 10
   description: An amusement park ride lands the Simpsons in outer space..
+  disneyplus_id:
   simpsonsworld_id: 379818563729
   good: maybe
   characters:
@@ -88,6 +98,7 @@ episodes:
   season: 26
   episode: 11
   description: Bart and Homer become BFF's.
+  disneyplus_id:
   simpsonsworld_id: 383002179865
   good: maybe
   characters:
@@ -95,6 +106,7 @@ episodes:
   season: 26
   episode: 12
   description: Homer becomes muse to Elon Musk.
+  disneyplus_id:
   simpsonsworld_id: 388773443652
   good: maybe
   characters:
@@ -102,6 +114,7 @@ episodes:
   season: 26
   episode: 13
   description: Springfield gets a new town anthem.
+  disneyplus_id:
   simpsonsworld_id: 395694659511
   good: maybe
   characters:
@@ -109,6 +122,7 @@ episodes:
   season: 26
   episode: 14
   description: Marge trades in her mom-chauffeur hat for a real one.
+  disneyplus_id:
   simpsonsworld_id: 399385667625
   good: maybe
   characters:
@@ -116,6 +130,7 @@ episodes:
   season: 26
   episode: 15
   description: Moe plots revenge over Nigerian e-mail scam.
+  disneyplus_id:
   simpsonsworld_id: 406163011894
   good: maybe
   characters:
@@ -123,6 +138,7 @@ episodes:
   season: 26
   episode: 16
   description: The Springfield congregation turns to gambling to repair the church.
+  disneyplus_id:
   simpsonsworld_id: 410018371522
   good: maybe
   characters:
@@ -131,6 +147,7 @@ episodes:
   episode: 17
   description: When Duffman undergoes hip replacement surgery and retires, the company
     sets up a reality show competition to find his replacement.
+  disneyplus_id:
   simpsonsworld_id: 420981315819
   good: maybe
   characters:
@@ -139,6 +156,7 @@ episodes:
   episode: 18
   description: Bart lies about being involved in a bulldozer crash, so Marge decides
     to follow him everywhere until he confesses.
+  disneyplus_id:
   simpsonsworld_id: 430426691868
   good: maybe
   characters:
@@ -148,6 +166,7 @@ episodes:
   description: When Homer gets an old film roll developed, the family takes a trip
     down memory lane to see the origins of how Bart and Lisa first started fighting
     with each other.
+  disneyplus_id:
   simpsonsworld_id: 434682947703
   good: maybe
   characters:
@@ -156,6 +175,7 @@ episodes:
   episode: 20
   description: The Simpsons learn about Grampa's days in the Air Force, and Bart takes
     up smoking to impress Milhouse's Dutch cousin.
+  disneyplus_id:
   simpsonsworld_id: 438408259807
   good: false
   characters:
@@ -166,6 +186,7 @@ episodes:
   episode: 21
   description: After Bart gets bullied at the school dance, Marge convinces the town
     to pass anti-bullying legislation.
+  disneyplus_id:
   simpsonsworld_id: 442879555692
   good: maybe
   characters:
@@ -174,6 +195,7 @@ episodes:
   episode: 22
   description: When a modernized Springfield Elementary has a technical meltdown,
     Lisa transforms it into a Waldorf school.
+  disneyplus_id:
   simpsonsworld_id: 446649411760
   good: maybe
   characters:

--- a/episodes/season_27.yml
+++ b/episodes/season_27.yml
@@ -6,6 +6,7 @@ episodes:
   description: Marge decides it's finally time to separate from Homer, and quickly
     moves on with her life. Homer is initially devastated, but soon stumbles into
     a romance with a younger woman.
+  disneyplus_id:
   simpsonsworld_id: 770426947744
   good: false
   characters:
@@ -16,6 +17,7 @@ episodes:
   episode: 2
   description: A celebrity television chef challenges Homer to a barbecue cook-off.
     But before the competition, Homer's new, prized barbecue grill is stolen.
+  disneyplus_id:
   simpsonsworld_id: 770595395906
   good: false
   characters:
@@ -28,6 +30,7 @@ episodes:
   description: Patty and Selma try to quit smoking, but Patty moves in with the Simpsons
     when Selma takes it up again. Meanwhile, Maggie goes on an adventure with some
     local creatures.
+  disneyplus_id:
   simpsonsworld_id: 772103747997
   good: maybe
   characters:
@@ -40,6 +43,7 @@ episodes:
   description: The Simpsons are proud to be the most festively decorated house on
     the block. But when Lisa is traumatized at Krustyland Horror Night, she feels
     she cannot handle Halloween anymore.
+  disneyplus_id:
   simpsonsworld_id: 770425923947
   good: maybe
   characters:
@@ -49,6 +53,7 @@ episodes:
   description: After killing Bart, Sideshow Bob doesn't know what to do with himself;
     Homer wakes up with short-term memory loss; Because of radiation, Lisa, Bart and
     Milhouse gain super-powers.
+  disneyplus_id:
   simpsonsworld_id: 770433091920
   good: maybe
   characters:
@@ -59,6 +64,7 @@ episodes:
   description: Lisa makes a new friend at school - Harper, who happens to be super-rich,
     while Homer makes friends with Harper's dad and sets out to continue living the
     good life when Lisa decides to end the friendship.
+  disneyplus_id:
   simpsonsworld_id: 770437187884
   good: maybe
   characters:
@@ -67,6 +73,7 @@ episodes:
   episode: 7
   description: Broadway legend Laney Fontaine transforms Lisa into a show-biz kid
     after Homer loses her chance at band camp.
+  disneyplus_id:
   simpsonsworld_id: 770417219938
   good: maybe
   characters:
@@ -75,6 +82,7 @@ episodes:
   episode: 8
   description: Lisa tries to restore the reputation of a forgotten Springfield female
     inventor, while Bart takes full advantage of a diagnosis that he is a sociopath.
+  disneyplus_id:
   simpsonsworld_id: 770422339536
   good: maybe
   characters:
@@ -84,6 +92,7 @@ episodes:
   description: A tale of Bart's journey from youth to adulthood, where he is constantly
     in search of approval from his father and in the shadow of his more-successful
     younger sister.
+  disneyplus_id:
   simpsonsworld_id: 1071531075851
   good: maybe
   characters:
@@ -93,6 +102,7 @@ episodes:
   description: When Homer loses his job due to Marge's social media post, he begins
     working as a dishwasher at a Greek restaurant. Meanwhile, Lisa creates an app
     that can predict the effect any post on social media will have.
+  disneyplus_id:
   simpsonsworld_id: 770434627559
   good: maybe
   characters:
@@ -102,6 +112,7 @@ episodes:
   description: Bart and Principal Skinner battle over the affection of Bart's new
     teacher, and a new milk-based product that Homer buys from the Kwik-E-Mart causes
     big changes in Bart and Lisa.
+  disneyplus_id:
   simpsonsworld_id: 770430019813
   good: maybe
   characters:
@@ -111,6 +122,7 @@ episodes:
   description: Apu's nephew makes big changes when he takes over the Kwik-E-Mart business,
     and Bart decides that he's through with being bad after his latest prank spirals
     out of control.
+  disneyplus_id:
   simpsonsworld_id: 770449475567
   good: maybe
   characters:
@@ -120,6 +132,7 @@ episodes:
   description: Professor Frink's new invention turns him into a ladies' man, while
     a new pill at the Springfield Retirement Castle causes Grandpa to hallucinate
     back to his happiest moments.
+  disneyplus_id:
   simpsonsworld_id: 770439747712
   good: maybe
   characters:
@@ -129,6 +142,7 @@ episodes:
   description: Lisa tries to launch the career of a homeless Appalachian folk singer,
     but Bart warns her that she will just let her down. Meanwhile, Homer tries to
     rescue the cat, who is trapped in the walls of the house.
+  disneyplus_id:
   simpsonsworld_id: 770451523845
   good: maybe
   characters:
@@ -138,6 +152,7 @@ episodes:
   description: Lisa takes a job as veterinarian's assistant, but soon lets the responsibilities
     of the job get to her head. Meanwhile, Marge decides to take a job as a crime
     scene cleaner.
+  disneyplus_id:
   simpsonsworld_id: 770452547696
   good: maybe
   characters:
@@ -147,6 +162,7 @@ episodes:
   description: Lisa signs up for an opportunity to be part of a mission to colonize
     Mars in ten years, and Homer's strategy to use reverse psychology to talk her
     out of it backfires.
+  disneyplus_id:
   simpsonsworld_id: 770891331927
   good: maybe
   characters:
@@ -156,6 +172,7 @@ episodes:
   description: Homer tries to raise Smithers' spirits by finding him a man, and Lisa
     gets the lead in the school production of "Casablanca" alongside a new male student,
     sparking Millhouse's jealousy.
+  disneyplus_id:
   simpsonsworld_id: 770893891557
   good: maybe
   characters:
@@ -165,6 +182,7 @@ episodes:
   description: After Lisa overhears Marge say that she doesn't like Lisa's jazz music,
     Marge takes Lisa on a trip to Capitol City to regain her friendship. Meanwhile,
     Bart uses Maggie as his new partner in crime for his practical jokes.
+  disneyplus_id:
   simpsonsworld_id: 770893891750
   good: maybe
   characters:
@@ -173,6 +191,7 @@ episodes:
   episode: 19
   description: Maggie will not go to sleep, so Homer tells her a bedtime story about
     when the Simpsons and the Flanders went together to the Grand Canyon.
+  disneyplus_id:
   simpsonsworld_id: 1071851075844
   good: maybe
   characters:
@@ -182,6 +201,7 @@ episodes:
   description: After promising Marge the trip of a lifetime, Homer makes a deal with
     a travel agent to be a courier of a top-secret briefcase in exchange for a discounted
     family vacation to Paris.
+  disneyplus_id:
   simpsonsworld_id: 772102211921
   good: maybe
   characters:
@@ -191,6 +211,7 @@ episodes:
   description: While trying to overcome a fear of public speaking, Homer creates an
     improv comedy troupe. Meanwhile, Marge rebuilds Bart's treehouse, but gets no
     thanks from him. Homer later appears live to answer phoned in questions.
+  disneyplus_id:
   simpsonsworld_id: 770892355976
   good: maybe
   characters:
@@ -199,6 +220,7 @@ episodes:
   episode: 22
   description: Marge lets Bart go to the park alone because he's too irritating, then
     she ends up getting arrested for leaving him unsupervised.
+  disneyplus_id:
   simpsonsworld_id: 772111939897
   good: maybe
   characters:

--- a/episodes/season_28.yml
+++ b/episodes/season_28.yml
@@ -4,6 +4,7 @@ episodes:
   season: 28
   episode: 1
   description: Mr. Burns puts on a variety show at the Springfield Bowl.
+  disneyplus_id:
   simpsonsworld_id: 1066704963871
   good: false
   characters:
@@ -15,6 +16,7 @@ episodes:
   episode: 2
   description: Homer finds a new friend in a woman who acts just like him when Mr.
     Burns hires the other Simpsons as his live-in virtual reality family.
+  disneyplus_id:
   simpsonsworld_id: 1064038980002
   good: false
   characters:
@@ -26,6 +28,7 @@ episodes:
   episode: 3
   description: Homer takes the family on a "hate-cation" to Boston after he catches
     Bart rooting for a rival football team.
+  disneyplus_id:
   simpsonsworld_id: 1064043075512
   good: false
   characters:
@@ -36,6 +39,7 @@ episodes:
   description: The children of Springfield fight to the death, Hunger Games style;
     Lisa's imaginary friend kills her real friends; Moe recruits Bart into his group
     of covert barfly agents.
+  disneyplus_id:
   simpsonsworld_id: 1063870531930
   good: false
   characters:
@@ -45,6 +49,7 @@ episodes:
   episode: 5
   description: Bart and Lisa investigate Krusty's new candy; Marge helps Homer dress
     for a promotion; Kent Brockman struggles with the changing media world.
+  disneyplus_id:
   simpsonsworld_id: 1064042051872
   good: maybe
   characters:
@@ -53,6 +58,7 @@ episodes:
   episode: 6
   description: Homer coaches the kids' lacrosse team with Kirk Van Houten, who disappears
     before the championship game, after Homer rants about him being a loser.
+  disneyplus_id:
   simpsonsworld_id: 1064041539874
   good: maybe
   characters:
@@ -61,6 +67,7 @@ episodes:
   episode: 7
   description: The Simpsons go to Cuba to get Grampa cheap medical care when the Retirement
     Castle and V.A. hospital are unable to solve his health problems.
+  disneyplus_id:
   simpsonsworld_id: 1064044099513
   good: maybe
   characters:
@@ -69,6 +76,7 @@ episodes:
   episode: 8
   description: Homer discovers an app that makes his life easier, while Grampa learns
     that he'll be a father again.
+  disneyplus_id:
   simpsonsworld_id: 1064046147533
   good: maybe
   characters:
@@ -78,6 +86,7 @@ episodes:
   description: Homer is placed in a cast following a workplace accident, leading Marge
     to receive romance from an unexpected source; Lisa attempts to keep the peace
     as bus monitor.
+  disneyplus_id:
   simpsonsworld_id: 1064046147517
   good: maybe
   characters:
@@ -86,6 +95,7 @@ episodes:
   episode: 10
   description: Krusty and his daughter spend Christmas with the Simpsons; Reverend
     Lovejoy seeks converts to boost attendance at church; A Christmas toy scares Maggie.
+  disneyplus_id:
   simpsonsworld_id: 1064045635565
   good: maybe
   characters:
@@ -94,6 +104,7 @@ episodes:
   episode: 11
   description: A Japanese book on minimalism inspires Marge to adapt to a new way
     of living, so the Simpsons have to part with items that no longer bring them joy.
+  disneyplus_id:
   simpsonsworld_id: 1070436931706
   good: maybe
   characters:
@@ -103,6 +114,7 @@ episodes:
   description: When all the fast food restaurants in Springfield become healthy, Homer
     turns to the last bastion of greasy food for comfort; Lisa must find a good news
     story when her school radio station is in jeopardy.
+  disneyplus_id:
   simpsonsworld_id: 1064044611770
   good: maybe
   characters:
@@ -111,6 +123,7 @@ episodes:
   episode: 15
   description: Bart deals with his guilt of betraying Lisa; Homer is revealed to be
     a master chess player.
+  disneyplus_id:
   simpsonsworld_id: 1064044611752
   good: maybe
   characters:
@@ -119,6 +132,7 @@ episodes:
   episode: 16
   description: Bart and Lisa return home following a traumatic incident at Kamp Krusty,
     putting an end to Homer and Marge's sexual encounters.
+  disneyplus_id:
   simpsonsworld_id: 1064043587996
   good: maybe
   characters:
@@ -126,6 +140,7 @@ episodes:
   season: 28
   episode: 17
   description: Bart becomes a star basketball player at Springfield Elementary.
+  disneyplus_id:
   simpsonsworld_id: 1064044099732
   good: maybe
   characters:
@@ -134,6 +149,7 @@ episodes:
   episode: 18
   description: As Homer and Marge try a different parenting style on Bart, Grampa
     gives him a special watch.
+  disneyplus_id:
   simpsonsworld_id: 1064046659528
   good: maybe
   characters:
@@ -142,6 +158,7 @@ episodes:
   episode: 19
   description: Mr. Burns starts his own for-profit university and hires Homer as a
     professor.
+  disneyplus_id:
   simpsonsworld_id: 1064044611790
   good: maybe
   characters:
@@ -149,6 +166,7 @@ episodes:
   season: 28
   episode: 20
   description: Bart befriends the grandmothers of Springfield.
+  disneyplus_id:
   simpsonsworld_id: 1064046659522
   good: maybe
   characters:
@@ -156,6 +174,7 @@ episodes:
   season: 28
   episode: 21
   description: Moe helps Homer and Marge work on their marriage.
+  disneyplus_id:
   simpsonsworld_id: 1064045635817
   good: maybe
   characters:
@@ -163,6 +182,7 @@ episodes:
   season: 28
   episode: 22
   description: The dogs of Springfield assert their dominance.
+  disneyplus_id:
   simpsonsworld_id: 1064045635799
   good: maybe
   characters:
@@ -172,6 +192,7 @@ episodes:
   description: Mr. Burns tries to relive his glory days, and crosses paths with a
     mysterious music mogul. After being conned by him and reduced to bankruptcy, Mr.
     Burns seeks revenge on the music producer.
+  disneyplus_id:
   simpsonsworld_id: 1077274179891
   good: maybe
   characters:

--- a/episodes/season_29.yml
+++ b/episodes/season_29.yml
@@ -5,6 +5,7 @@ episodes:
   episode: 1
   description: In a world of magic, Marge's mother is transformed into an Ice Walker
     and must rely on Lisa to use magic to help Homer afford the cure.
+  disneyplus_id:
   simpsonsworld_id: 1075435075944
   good: maybe
   characters:
@@ -13,6 +14,7 @@ episodes:
   episode: 2
   description: Marge and Lisa decide to turns an unpleasant experience Lisa had into
     a successful graphic novel.
+  disneyplus_id:
   simpsonsworld_id: 1080357443795
   good: maybe
   characters:
@@ -21,6 +23,7 @@ episodes:
   episode: 3
   description: Homer stumbles upon Maggie's incredible talent for whistling and decides
     to start her on the path to becoming a baby celebrity.
+  disneyplus_id:
   simpsonsworld_id: 1073411651711
   good: maybe
   characters:
@@ -30,6 +33,7 @@ episodes:
   description: Maggie's body is overwhelmed by the malice of an ancient demon; in
     an alternate dimension, Lisa stumbles upon a disturbingly perfect version of her
     family.
+  disneyplus_id:
   simpsonsworld_id: 1078509635693
   good: false
   characters:
@@ -39,6 +43,7 @@ episodes:
   episode: 5
   description: Grampa Simpson is finally able to hear the various things that people
     say about him after he receives a new hearing aid.
+  disneyplus_id:
   simpsonsworld_id: 1088584771605
   good: maybe
   characters:
@@ -47,6 +52,7 @@ episodes:
   episode: 6
   description: Marge decides to enter the race to become the next mayor of Springfield
     as she grows increasingly frustrated with how the local government operates.
+  disneyplus_id:
   simpsonsworld_id: 1094410819778
   good: maybe
   characters:
@@ -55,6 +61,7 @@ episodes:
   episode: 7
   description: Homer and the guys try helping Moe cheer up by getting their old bowling
     team back together again, but they soon face a team of arrogant millionaires.
+  disneyplus_id:
   simpsonsworld_id: 1099353155881
   good: maybe
   characters:
@@ -63,6 +70,7 @@ episodes:
   episode: 8
   description: In the future, Lisa works on writing her Harvard college application
     essay by reflecting on how certain disappointing birthdays made her who she is.
+  disneyplus_id:
   simpsonsworld_id: 1108700739531
   good: maybe
   characters:
@@ -71,6 +79,7 @@ episodes:
   episode: 9
   description: When Bart suddenly disappears, the town organizes a search party in
     the hopes of finding him.
+  disneyplus_id:
   simpsonsworld_id: 1113094211783
   good: maybe
   characters:
@@ -79,6 +88,7 @@ episodes:
   episode: 10
   description: While the Simpson family attends a STEM conference, Lisa becomes attracted
     to a pianist and Bart learns about his natural talent for chemistry.
+  disneyplus_id:
   simpsonsworld_id: 1131039811958
   good: maybe
   characters:
@@ -87,6 +97,7 @@ episodes:
   episode: 11
   description: When Mr. Burns begins to worry that the world is coming to an end,
     he starts testing all of the residents of to figure out who would be worth saving.
+  disneyplus_id:
   simpsonsworld_id: 1136372803875
   good: maybe
   characters:
@@ -94,6 +105,7 @@ episodes:
   season: 29
   episode: 12
   description: Homer learns to love a piece of art.
+  disneyplus_id:
   simpsonsworld_id:
   good: maybe
   characters:
@@ -101,6 +113,7 @@ episodes:
   season: 29
   episode: 13
   description: The Simpsons visit their old apartment and remember the days without their kids.
+  disneyplus_id:
   simpsonsworld_id:
   good: maybe
   characters:
@@ -108,6 +121,7 @@ episodes:
   season: 29
   episode: 14
   description: Due to a general fear of clowns, Krusty can no longer do his job.
+  disneyplus_id:
   simpsonsworld_id:
   good: maybe
   characters:
@@ -115,6 +129,7 @@ episodes:
   season: 29
   episode: 15
   description: Bart tries to conquer Homer with help from a book.
+  disneyplus_id:
   simpsonsworld_id:
   good: maybe
   characters:
@@ -122,6 +137,7 @@ episodes:
   season: 29
   episode: 16
   description: Moe inherits a mattress business from his father.
+  disneyplus_id:
   simpsonsworld_id:
   good: maybe
   characters:
@@ -129,6 +145,7 @@ episodes:
   season: 29
   episode: 17
   description: The family goes to New Orleans where they try to recover from various traumas.
+  disneyplus_id:
   simpsonsworld_id:
   good: maybe
   characters:
@@ -136,6 +153,7 @@ episodes:
   season: 29
   episode: 18
   description: Grampa is about to die when he reveals a terrible secret.
+  disneyplus_id:
   simpsonsworld_id:
   good: maybe
   characters:
@@ -143,6 +161,7 @@ episodes:
   season: 29
   episode: 19
   description: Flanders loses his business and works with Homer at the plant.
+  disneyplus_id:
   simpsonsworld_id:
   good: maybe
   characters:
@@ -150,6 +169,7 @@ episodes:
   season: 29
   episode: 20
   description: The Simpsons visit Denmark and everyone but Homer falls in love with the happy country.
+  disneyplus_id:
   simpsonsworld_id:
   good: maybe
   characters:
@@ -157,6 +177,7 @@ episodes:
   season: 29
   episode: 21
   description: Bart is struck by lightning and has horrible dreams.
+  disneyplus_id:
   simpsonsworld_id:
   good: maybe
   characters:

--- a/episodes/season_30.yml
+++ b/episodes/season_30.yml
@@ -1,4 +1,5 @@
-
+---
+episodes:
 - title: Bart's Not Dead
   season: 30
   episode: 1
@@ -62,7 +63,7 @@
   simpsonsworld_id:
   good: maybe
   characters:
-- title: 'Tis the 30th Season
+- title: "'Tis the 30th Season"
   season: 30
   episode: 10
   description: The Simpsons try to spend a relaxing Florida Christmas.

--- a/episodes/season_30.yml
+++ b/episodes/season_30.yml
@@ -4,6 +4,7 @@ episodes:
   season: 30
   episode: 1
   description: Bart's cover for his lie backfires.
+  disneyplus_id:
   simpsonsworld_id:
   good: maybe
   characters:
@@ -11,6 +12,7 @@ episodes:
   season: 30
   episode: 2
   description: Homer and Marge go on an amazing race type show where they are eliminated immediately.
+  disneyplus_id:
   simpsonsworld_id:
   good: maybe
   characters:
@@ -18,6 +20,7 @@ episodes:
   season: 30
   episode: 3
   description: The Simpsons explore three ways to get into heaven.
+  disneyplus_id:
   simpsonsworld_id:
   good: maybe
   characters:
@@ -25,6 +28,7 @@ episodes:
   season: 30
   episode: 4
   description: The Simpsons battle spores from space and Grampa goes to a Jurassic Park-style senior home.
+  disneyplus_id:
   simpsonsworld_id:
   good: maybe
   characters:
@@ -32,6 +36,7 @@ episodes:
   season: 30
   episode: 5
   description: Marge and Homer work together at a cool tech company.
+  disneyplus_id:
   simpsonsworld_id:
   good: maybe
   characters:
@@ -39,6 +44,7 @@ episodes:
   season: 30
   episode: 6
   description: Bart orders a Russian bride for Moe. She turns Moe's life around, and he falls in love.
+  disneyplus_id:
   simpsonsworld_id:
   good: maybe
   characters:
@@ -46,6 +52,7 @@ episodes:
   season: 30
   episode: 7
   description: Marge becomes a successful Tupperware saleswoman because customers think she's a man in drag.
+  disneyplus_id:
   simpsonsworld_id:
   good: maybe
   characters:
@@ -53,6 +60,7 @@ episodes:
   season: 30
   episode: 8
   description: Homer becomes an internet recapper while Krusty joins the circus.
+  disneyplus_id:
   simpsonsworld_id:
   good: maybe
   characters:
@@ -60,6 +68,7 @@ episodes:
   season: 30
   episode: 9
   description: Lisa reads "To Kill a Mockingbird" and observes similarities between her dad and Atticus Finch.
+  disneyplus_id:
   simpsonsworld_id:
   good: maybe
   characters:
@@ -67,6 +76,7 @@ episodes:
   season: 30
   episode: 10
   description: The Simpsons try to spend a relaxing Florida Christmas.
+  disneyplus_id:
   simpsonsworld_id:
   good: maybe
   characters:
@@ -74,6 +84,7 @@ episodes:
   season: 30
   episode: 11
   description: Grampa learns a startling secret from his past. It takes him to Texas to find a long-lost life.
+  disneyplus_id:
   simpsonsworld_id:
   good: maybe
   characters:
@@ -81,6 +92,7 @@ episodes:
   season: 30
   episode: 12
   description: Lisa discovers the ideal family... and lies about her own.
+  disneyplus_id:
   simpsonsworld_id:
   good: maybe
   characters:
@@ -88,6 +100,7 @@ episodes:
   season: 30
   episode: 13
   description: When Homer breaks a promise and binge watches a show without Marge, she is more furious than ever.
+  disneyplus_id:
   simpsonsworld_id:
   good: maybe
   characters:
@@ -95,6 +108,7 @@ episodes:
   season: 30
   episode: 14
   description: On a podcast Krusty discusses a lost film he made in the ‘80s.
+  disneyplus_id:
   simpsonsworld_id:
   good: maybe
   characters:
@@ -102,6 +116,7 @@ episodes:
   season: 30
   episode: 15
   description: Homer goes on a joyride and is threatened with prison by Comic Book Guy.
+  disneyplus_id:
   simpsonsworld_id:
   good: maybe
   characters:
@@ -109,6 +124,7 @@ episodes:
   season: 30
   episode: 16
   description: Homer gets an inguinal hernia which comes to life and tells him to take it easy.
+  disneyplus_id:
   simpsonsworld_id:
   good: maybe
   characters:
@@ -116,6 +132,7 @@ episodes:
   season: 30
   episode: 17
   description: Bart earns money in a video game competition, and Homer becomes his coach.
+  disneyplus_id:
   simpsonsworld_id:
   good: maybe
   characters:
@@ -123,6 +140,7 @@ episodes:
   season: 30
   episode: 18
   description: Bart is upset to learn there is a new, all-girl version of Itchy and Scratchy.
+  disneyplus_id:
   simpsonsworld_id:
   good: maybe
   characters:
@@ -130,6 +148,7 @@ episodes:
   season: 30
   episode: 19
   description: Lisa joins an advanced youth orchestra in Capital City, throwing the family’s lives into havoc.
+  disneyplus_id:
   simpsonsworld_id:
   good: maybe
   characters:
@@ -137,6 +156,7 @@ episodes:
   season: 30
   episode: 20
   description: Marge becomes director of a local theater production.
+  disneyplus_id:
   simpsonsworld_id:
   good: maybe
   characters:
@@ -144,6 +164,7 @@ episodes:
   season: 30
   episode: 21
   description: Lisa goes to Canada and refuses to leave. A desperate Marge tries to get her back.
+  disneyplus_id:
   simpsonsworld_id:
   good: maybe
   characters:
@@ -151,6 +172,7 @@ episodes:
   season: 30
   episode: 22
   description: $600 theft rocks the Simpson home. A local TV crime show attempts to crack it to no avail.
+  disneyplus_id:
   simpsonsworld_id:
   good: maybe
   characters:
@@ -158,6 +180,7 @@ episodes:
   season: 30
   episode: 23
   description: Marge sells crystals and makes a fortune.
+  disneyplus_id:
   simpsonsworld_id:
   good: maybe
   characters:

--- a/simpsons_data.json
+++ b/simpsons_data.json
@@ -5,6 +5,7 @@
             "season": 1,
             "episode": 1,
             "description": "Homer decides to gamble on a \"hunch\" at the dog track when his annual Christmas bonus is canceled.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 273376835817,
             "good": false,
             "characters": [
@@ -16,6 +17,7 @@
             "season": 1,
             "episode": 2,
             "description": "Bart is believed to be a genius after he switches I.Q. tests with brainy Martin Prince.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 283744835990,
             "good": false,
             "characters": [
@@ -27,6 +29,7 @@
             "season": 1,
             "episode": 3,
             "description": "Fired from his job at the Nuclear Power Plant, Homer decides to embark on a campaign to make all of Springfield safer.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 273381443699,
             "good": false,
             "characters": [
@@ -38,6 +41,7 @@
             "season": 1,
             "episode": 4,
             "description": "After attending the annual company picnic, Homer becomes jealous of fellow employees with 'normal' families.  He decides to enlist the aid of psychologist Marvin Monroe to treat his wife and children.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 273392195780,
             "good": true,
             "characters": [
@@ -50,6 +54,7 @@
             "season": 1,
             "episode": 5,
             "description": "Grandpa Simpson aids Bart in his war against a school bully and his gang.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 300934723994,
             "good": false,
             "characters": [
@@ -62,6 +67,7 @@
             "season": 1,
             "episode": 6,
             "description": "Lisa befriends a saxophone player when she develops a case of the blues.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 273391683535,
             "good": false,
             "characters": [
@@ -74,6 +80,7 @@
             "season": 1,
             "episode": 7,
             "description": "Homer is mistaken for Bigfoot when he takes his family on a trip into the wilderness in their new camper.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 273396803837,
             "good": false,
             "characters": [
@@ -86,6 +93,7 @@
             "season": 1,
             "episode": 8,
             "description": "Bart attempts to impress his new friends by vandalizing a statue of the town's founding father, Jebediah Springfield.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 305663555641,
             "good": true,
             "characters": [
@@ -98,6 +106,7 @@
             "season": 1,
             "episode": 9,
             "description": "Marge contemplates having an affair with a local womanizer after Homer selfishly buys her a bowling ball for her birthday.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 280384579592,
             "good": false,
             "characters": [
@@ -109,6 +118,7 @@
             "season": 1,
             "episode": 10,
             "description": "Bart photographs Homer with belly-dancer Princess Kashmir.  Marge will only forgive her husband when he proves to Bart that all women are not merely sexual objects.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 275197507879,
             "good": false,
             "characters": [
@@ -121,6 +131,7 @@
             "season": 1,
             "episode": 11,
             "description": "To Homer's delight, Bart is sent to France for the summer as part of a student exchange program.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 306382403766,
             "good": true,
             "characters": [
@@ -132,6 +143,7 @@
             "season": 1,
             "episode": 12,
             "description": "When Homer positively identifies Krusty the Clown as an armed robber, Bart attempts to clear his idol's name.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 288019523914,
             "good": true,
             "characters": [
@@ -144,6 +156,7 @@
             "season": 1,
             "episode": 13,
             "description": "Marge and Homer unwittingly leave their children in the care of a villainous babysitter when they attempt to rekindle their marriage.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 274504771647,
             "good": false,
             "characters": [
@@ -155,6 +168,7 @@
             "season": 2,
             "episode": 1,
             "description": "Bart must pass a critical history test or he will be held back a grade.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 260539459671,
             "good": false,
             "characters": [
@@ -166,6 +180,7 @@
             "season": 2,
             "episode": 2,
             "description": "Homer's life changes dramatically when he purchases a miracle hair growth formula.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 260539971564,
             "good": true,
             "characters": [
@@ -177,6 +192,7 @@
             "season": 2,
             "episode": 3,
             "description": "The Simpsons tell three bloodcurdling tales of horror on Halloween night.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 260538435884,
             "good": true,
             "characters": [
@@ -188,6 +204,7 @@
             "season": 2,
             "episode": 4,
             "description": "Homer supports Mr. Burns in his bid for governor, but Marge remains loyal to Burns's political opposition.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 260537411822,
             "good": true,
             "characters": [
@@ -201,6 +218,7 @@
             "season": 2,
             "episode": 5,
             "description": "Homer becomes the official mascot for a major league baseball team.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 260538435888,
             "good": true,
             "characters": [
@@ -212,6 +230,7 @@
             "season": 2,
             "episode": 6,
             "description": "Homer and Ned Flanders pressure their sons to win a miniature golf championship.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 260539459670,
             "good": true,
             "characters": [
@@ -225,6 +244,7 @@
             "season": 2,
             "episode": 7,
             "description": "Bart learns the true meaning of Thanksgiving when he runs away from home after having an argument with Lisa.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 260539459701,
             "good": false,
             "characters": [
@@ -237,6 +257,7 @@
             "season": 2,
             "episode": 8,
             "description": "Bart is determined to leap a gorge on his skateboard after witnessing the death defying stunts of a real daredevil.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 260539459702,
             "good": true,
             "characters": [
@@ -248,6 +269,7 @@
             "season": 2,
             "episode": 9,
             "description": "Marge initiates a protest movement against gratuitous violence on television when Maggie begins acting aggressively after viewing Itchy and Scratchy cartoons.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 1094123075920,
             "good": true,
             "characters": [
@@ -259,6 +281,7 @@
             "season": 2,
             "episode": 10,
             "description": "When Mr. Burns hits Bart with his car, Homer is enticed by a disreputable lawyer to sue him.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 260550723760,
             "good": true,
             "characters": [
@@ -272,6 +295,7 @@
             "season": 2,
             "episode": 11,
             "description": "Homer believes he has only twenty-four hours to live after he eats an improperly prepared blowfish.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 260548675839,
             "good": true,
             "characters": [
@@ -283,6 +307,7 @@
             "season": 2,
             "episode": 12,
             "description": "Marge recounts to her children how she and Homer first met and fell in love.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 260549187876,
             "good": false,
             "characters": [
@@ -295,6 +320,7 @@
             "season": 2,
             "episode": 13,
             "description": "Lisa disapproves when Homer has cable television installed illegally into their home.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 260820547692,
             "good": true,
             "characters": [
@@ -307,6 +333,7 @@
             "season": 2,
             "episode": 14,
             "description": "Homer arranges a date between Principal Skinner and Marge's sister, Selma.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 263496771968,
             "good": true,
             "characters": [
@@ -320,6 +347,7 @@
             "season": 2,
             "episode": 15,
             "description": "Homer locates his long lost half brother Herb and discovers that he is rich.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 1094123587812,
             "good": false,
             "characters": [
@@ -331,6 +359,7 @@
             "season": 2,
             "episode": 16,
             "description": "Bart must help train Santa's Little Helper to pass an obedience course or Homer will give the dog away.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 272034883946,
             "good": true,
             "characters": [
@@ -343,6 +372,7 @@
             "season": 2,
             "episode": 17,
             "description": "Grampa Simpson falls in love... and inherits a fortune.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 263504963955,
             "good": false,
             "characters": [
@@ -354,6 +384,7 @@
             "season": 2,
             "episode": 18,
             "description": "Marge renews her interest in becoming an artist after Homer finds an old painting of Ringo Starr in the attic.  Mr. Burns commissions Marge to paint a portrait of him.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 1094212163883,
             "good": true,
             "characters": [
@@ -366,6 +397,7 @@
             "season": 2,
             "episode": 19,
             "description": "Lisa develops a crush on her substitute teacher, Mr. Bergstrom.  Bergstrom tells Homer he must learn to act as a positive role model for his daughter.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 288011331912,
             "good": true,
             "characters": [
@@ -377,6 +409,7 @@
             "season": 2,
             "episode": 20,
             "description": "Marge insists Homer accompany her for a weekend of marriage counseling at a wooded retreat, but Homer takes advantage of the location to attempt to catch a legendary catfish.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 272040003661,
             "good": true,
             "characters": [
@@ -389,6 +422,7 @@
             "season": 2,
             "episode": 21,
             "description": "Bart and his friends pool their money to purchase the first issue of \"Radioactive Man\" comics, but then cannot decide who gets to keep it.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 310368835964,
             "good": true,
             "characters": [
@@ -402,6 +436,7 @@
             "season": 2,
             "episode": 22,
             "description": "Homer expects a generous gift in return when he donates Bart's blood to an ailing Mr. Burns.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 272041539932,
             "good": true,
             "characters": [
@@ -414,6 +449,7 @@
             "season": 3,
             "episode": 1,
             "description": "Homer is institutionalized after Bart fills out his sanity test.  A man who thinks he is Michael Jackson helps Bart write a song for Lisa when he forgets her birthday.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 272234051980,
             "good": false,
             "characters": [
@@ -425,6 +461,7 @@
             "season": 3,
             "episode": 2,
             "description": "The Simpsons travel to the Nation's Capitol when Lisa becomes a semifinalist in an essay contest on patriotism.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 275196995796,
             "good": true,
             "characters": [
@@ -436,6 +473,7 @@
             "season": 3,
             "episode": 3,
             "description": "Ned Flanders opens a store for left-handed people and Homer is overjoyed when it performs poorly.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 272051267562,
             "good": true,
             "characters": [
@@ -448,6 +486,7 @@
             "season": 3,
             "episode": 4,
             "description": "Bart fraternizes with a gang of mobsters and becomes the prime suspect when Principal Skinner mysteriously disappears.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 288015427922,
             "good": true,
             "characters": [
@@ -460,6 +499,7 @@
             "season": 3,
             "episode": 5,
             "description": "Homer becomes a hero when he averts a catastrophe at the power plant, but what is perceived as his skill of being a quick thinker is actually dumb luck.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 256843843704,
             "good": true,
             "characters": [
@@ -471,6 +511,7 @@
             "season": 3,
             "episode": 6,
             "description": "Bart and Lisa scheme to reunite Krusty the Clown with his father, Rabbi Krustofsky, who disowned him for not carrying on the family tradition.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 256874051703,
             "good": true,
             "characters": [
@@ -484,6 +525,7 @@
             "season": 3,
             "episode": 7,
             "description": "The Simpsons eat too much candy on Halloween and experience nightmarish tales of horror while they sleep.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 272054339616,
             "good": true,
             "characters": [
@@ -495,6 +537,7 @@
             "season": 3,
             "episode": 8,
             "description": "Homer realizes that he never shows Lisa the attention she deserves and buys her a pony.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 310374467809,
             "good": false,
             "characters": [
@@ -507,6 +550,7 @@
             "season": 3,
             "episode": 9,
             "description": "Realizing he has not been a good father to Bart, Homer aids his son in building a soap box racer.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 256898115598,
             "good": true,
             "characters": [
@@ -519,6 +563,7 @@
             "season": 3,
             "episode": 10,
             "description": "Homer gives Moe the recipe for a unique alcoholic drink, and when it turns into a sensation, Moe takes credit, and the profits, from its success.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 305663555961,
             "good": true,
             "characters": [
@@ -531,6 +576,7 @@
             "season": 3,
             "episode": 11,
             "description": "Homer is fired from his job when a German firm buys the power plant from Mr. Burns.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 310380099512,
             "good": false,
             "characters": [
@@ -542,6 +588,7 @@
             "season": 3,
             "episode": 12,
             "description": "When Marge believes she may be pregnant, Homer recounts how Bart was born.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 299618371603,
             "good": false,
             "characters": [
@@ -554,6 +601,7 @@
             "season": 3,
             "episode": 13,
             "description": "Using his Superstar Celebrity microphone, Bart tricks all of Springfield into believing that a child has fallen down a well.  But when he falls into the same well, Bart cannot get anyone to save him.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 272052803895,
             "good": true,
             "characters": [
@@ -565,6 +613,7 @@
             "season": 3,
             "episode": 14,
             "description": "Lisa accurately predicts the winners of sporting events that Homer gambles on so she can be closer to her father.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 273404483565,
             "good": true,
             "characters": [
@@ -577,6 +626,7 @@
             "season": 3,
             "episode": 15,
             "description": "When Marge reaches the breaking point, she leaves for a much needed vacation, leaving the rest of the family to realize how much she does for them.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 272224835795,
             "good": false,
             "characters": [
@@ -589,6 +639,7 @@
             "season": 3,
             "episode": 16,
             "description": "When Bart discovers that his divorced teacher, Mrs. Krabappel, has placed a \"personals\" ad in the local newspaper, he decides to create fake correspondence.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 272228931984,
             "good": true,
             "characters": [
@@ -601,6 +652,7 @@
             "season": 3,
             "episode": 17,
             "description": "Mr. Burns bets one million dollars that his power plant's softball team will win the championship, then hires professional baseball players to be members of the team.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 310380099768,
             "good": true,
             "characters": [
@@ -613,6 +665,7 @@
             "season": 3,
             "episode": 18,
             "description": "Bart finds new respect for the law and Lisa hangs out with the wrong crowd after they both take career aptitude tests.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 263513155607,
             "good": true,
             "characters": [
@@ -625,6 +678,7 @@
             "season": 3,
             "episode": 19,
             "description": "The Simpsons must choose between frills and their dog when Santa's Little Helper needs an expensive operation to save its life.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 274404419620,
             "good": true,
             "characters": [
@@ -637,6 +691,7 @@
             "season": 3,
             "episode": 20,
             "description": "Homer becomes the manager of a beautiful Country Western singer.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 272215619762,
             "good": true,
             "characters": [
@@ -648,6 +703,7 @@
             "season": 3,
             "episode": 21,
             "description": "To Bart's horror, Selma announces that her husband-to-be is none other than Sideshow Bob.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 272221251812,
             "good": true,
             "characters": [
@@ -660,6 +716,7 @@
             "season": 3,
             "episode": 22,
             "description": "Bart attends a Spinal Tap concert.  Otto loses his job driving the school bus and moves in with the Simpsons.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 279103043694,
             "good": true,
             "characters": [
@@ -672,6 +729,7 @@
             "season": 3,
             "episode": 23,
             "description": "Bart becomes jealous when Milhouse falls for a girl who transferred to their school.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 280393283967,
             "good": true,
             "characters": [
@@ -684,6 +742,7 @@
             "season": 3,
             "episode": 24,
             "description": "Herb Powell asks his brother Homer to let him borrow $2000 to develop a new invention: a translator of baby gibberish.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 279098435798,
             "good": false,
             "characters": [
@@ -696,6 +755,7 @@
             "season": 4,
             "episode": 1,
             "description": "Bart and Lisa are horrified when their summer at Kamp Krusty turns into a nightmare.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 279133251579,
             "good": true,
             "characters": [
@@ -708,6 +768,7 @@
             "season": 4,
             "episode": 2,
             "description": "When Marge lands the role of Blanche in a local production of \"A Streetcar Named Desire,\" Homer cannot hide his disinterest.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 273537603751,
             "good": true,
             "characters": []
@@ -717,6 +778,7 @@
             "season": 4,
             "episode": 3,
             "description": "Homer creates his own religion as a means of escaping church services on Sundays.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 279137859827,
             "good": true,
             "characters": [
@@ -728,6 +790,7 @@
             "season": 4,
             "episode": 4,
             "description": "Homer enters Lisa in a beauty pageant when her self-esteem plummets.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 273537603930,
             "good": true,
             "characters": [
@@ -740,6 +803,7 @@
             "season": 4,
             "episode": 5,
             "description": "During a Halloween party, the Simpsons tell three horrifying tales of the macabre.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 305668675610,
             "good": true,
             "characters": [
@@ -751,6 +815,7 @@
             "season": 4,
             "episode": 6,
             "description": "Homer forbids his son from seeing a new movie about his favorite cartoon heroes as punishment for misbehaving.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 278803011830,
             "good": true,
             "characters": [
@@ -763,6 +828,7 @@
             "season": 4,
             "episode": 7,
             "description": "When the foundation to the Simpsons' house is need of an expensive repair, Marge takes a position at the power plant where Homer works.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 299613763656,
             "good": false,
             "characters": [
@@ -774,6 +840,7 @@
             "season": 4,
             "episode": 8,
             "description": "Bart falls in love with the girl who moves in next door, only to find that she prefers the school bully.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 273542211871,
             "good": false,
             "characters": [
@@ -786,6 +853,7 @@
             "season": 4,
             "episode": 9,
             "description": "Homer and Barney vie for Springfield's lucrative snow plowing business.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 273544259768,
             "good": true,
             "characters": [
@@ -798,6 +866,7 @@
             "season": 4,
             "episode": 10,
             "description": "Marge recounts how Lisa first spoke as the family awaits baby Maggie's first word.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 288026691837,
             "good": false,
             "characters": [
@@ -809,6 +878,7 @@
             "season": 4,
             "episode": 11,
             "description": "Homer suffers a heart attack and hires Dr. Nick Riviera to perform a delicate triple bypass operation.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 273548355538,
             "good": true,
             "characters": [
@@ -820,6 +890,7 @@
             "season": 4,
             "episode": 12,
             "description": "An unscrupulous profiteer sells the people of Springfield on a defective monorail system, with Homer as the conductor.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 306386499796,
             "good": true,
             "characters": [
@@ -832,6 +903,7 @@
             "season": 4,
             "episode": 13,
             "description": "Selma decides to take her dead aunt's advice and have children before it is too late.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 310386755912,
             "good": true,
             "characters": [
@@ -845,6 +917,7 @@
             "season": 4,
             "episode": 14,
             "description": "Bart tires of Homer's lack of interest in him and chooses another father from the Bigger Brother program.  Lisa struggles to kick the habit of dialing a 900 number.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 274103363992,
             "good": false,
             "characters": [
@@ -858,6 +931,7 @@
             "season": 4,
             "episode": 15,
             "description": "Lisa feels pity for Ralph, a nerdy classmate, and gives him a card on Valentine's Day. But to her horror, Ralph develops a crush on her.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 274107459686,
             "good": true,
             "characters": [
@@ -870,6 +944,7 @@
             "season": 4,
             "episode": 16,
             "description": "Marge convinces Homer he may have a drinking problem. Lisa plots to humiliate Bart with her science project after he ruins an experiment.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 277249603926,
             "good": true,
             "characters": []
@@ -879,6 +954,7 @@
             "season": 4,
             "episode": 17,
             "description": "Homer is elected union leader at the power plant and tries to save the dental plan so he will not have to pay for Lisa's new braces.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 357630019692,
             "good": true,
             "characters": [
@@ -891,6 +967,7 @@
             "season": 4,
             "episode": 18,
             "description": "Family and friends reminisce about Homer's life after Bart's April Fools' Day prank sends him to the hospital.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 305670723781,
             "good": false,
             "characters": [
@@ -902,6 +979,7 @@
             "season": 4,
             "episode": 19,
             "description": "Using Grandpa as a front, Lisa and Bart write their own \"Itchy and Scratchy\" cartoons.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 288029763650,
             "good": true,
             "characters": [
@@ -915,6 +993,7 @@
             "season": 4,
             "episode": 20,
             "description": "Lisa seeks to end a local holiday in which snakes are chased into town and beaten with sticks.  Bart is expelled from school by Principal Skinner.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 288129091929,
             "good": true,
             "characters": []
@@ -924,6 +1003,7 @@
             "season": 4,
             "episode": 21,
             "description": "Marge is jailed when she is convicted of stealing from Apu's convenience store.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 299606595657,
             "good": false,
             "characters": []
@@ -933,6 +1013,7 @@
             "season": 4,
             "episode": 22,
             "description": "Bart, Lisa and a group of celebrities help Krusty turn his career around after his television show is canceled.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 274256963874,
             "good": true,
             "characters": [
@@ -946,6 +1027,7 @@
             "season": 5,
             "episode": 1,
             "description": "Homer recounts his phenomenal rise to superstardom as a member of the barbershop quartet, The Be Sharps.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 305674307809,
             "good": false,
             "characters": [
@@ -960,6 +1042,7 @@
             "season": 5,
             "episode": 2,
             "description": "Sideshow Bob terrorizes Bart after he is paroled from prison.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 305674819788,
             "good": true,
             "characters": [
@@ -972,6 +1055,7 @@
             "season": 5,
             "episode": 3,
             "description": "Homer enrolls in a nuclear physics class at Springfield University and convinces three nerdy classmates to help him pull off a prank.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 280399427649,
             "good": true,
             "characters": [
@@ -983,6 +1067,7 @@
             "season": 5,
             "episode": 4,
             "description": "The Simpsons find Mr. Burns' long-lost childhood teddy bear.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 279714371653,
             "good": true,
             "characters": [
@@ -995,6 +1080,7 @@
             "season": 5,
             "episode": 5,
             "description": "In a ghoulish gallery, Bart hosts three bloodcurdling tales of Halloween horror.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 275206211805,
             "good": true,
             "characters": [
@@ -1006,6 +1092,7 @@
             "season": 5,
             "episode": 6,
             "description": "Marge joins divorcee Ruth Powers for a wild night on the town, only to discover that her friend is driving a stolen vehicle.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 294777411510,
             "good": true,
             "characters": [
@@ -1017,6 +1104,7 @@
             "season": 5,
             "episode": 7,
             "description": "The host of a self-help workshop convinces the people of Springfield they should emulate Bart's uninhibited personality.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 275202627817,
             "good": true,
             "characters": [
@@ -1028,6 +1116,7 @@
             "season": 5,
             "episode": 8,
             "description": "Bart inadvertently joins the Junior Campers, and during a rafting trip, he becomes lost at sea with Homer and Ned Flanders.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 288056387698,
             "good": true,
             "characters": [
@@ -1041,6 +1130,7 @@
             "season": 5,
             "episode": 9,
             "description": "Homer is attracted to a sexy co-worker with a personality identical to his own.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 275201091952,
             "good": true,
             "characters": [
@@ -1052,6 +1142,7 @@
             "season": 5,
             "episode": 10,
             "description": "Marge becomes addicted to playing slot machines after the town of Springfield legalizes gambling.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 305659459565,
             "good": true,
             "characters": [
@@ -1064,6 +1155,7 @@
             "season": 5,
             "episode": 11,
             "description": "Homer takes the law into his own hands after Springfield is victimized by a cat burglar.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 305677891810,
             "good": true,
             "characters": [
@@ -1075,6 +1167,7 @@
             "season": 5,
             "episode": 12,
             "description": "Bart becomes an instant celebrity after he ad-libs a line during a sketch on the \"Krusty the Klown Show.\"",
+            "disneyplus_id": null,
             "simpsonsworld_id": 302789187885,
             "good": true,
             "characters": [
@@ -1087,6 +1180,7 @@
             "season": 5,
             "episode": 13,
             "description": "Apu offers the Simpsons his services as valet after he is fired from the Kwik-E-Mart for selling rancid meat.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 279716931614,
             "good": false,
             "characters": [
@@ -1099,6 +1193,7 @@
             "season": 5,
             "episode": 14,
             "description": "Lisa manufactures her own talking doll for little girls.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 274260035625,
             "good": true,
             "characters": [
@@ -1110,6 +1205,7 @@
             "season": 5,
             "episode": 15,
             "description": "NASA scientists train Homer to become the first average American in space, with near disastrous results.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 275720259883,
             "good": true,
             "characters": [
@@ -1122,6 +1218,7 @@
             "season": 5,
             "episode": 16,
             "description": "Flanders is horrified to discover he has become Homer's best friend.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 310398019629,
             "good": false,
             "characters": []
@@ -1131,6 +1228,7 @@
             "season": 5,
             "episode": 17,
             "description": "Bart wins a full grown African elephant as part of a radio contest.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 275726403611,
             "good": false,
             "characters": []
@@ -1140,6 +1238,7 @@
             "season": 5,
             "episode": 18,
             "description": "Mr. Burns chooses Bart as the heir to his vast fortune.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 283747395787,
             "good": false,
             "characters": []
@@ -1149,6 +1248,7 @@
             "season": 5,
             "episode": 19,
             "description": "Bart suffers enormous guilt after Skinner is fired from his job as school principal.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 274260035741,
             "good": true,
             "characters": [
@@ -1161,6 +1261,7 @@
             "season": 5,
             "episode": 20,
             "description": "Only Bart can clear Mayor Quimby's nephew of an assault charge, but he fears that identifying himself as a witness will mean expulsion for skipping class.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 278796355962,
             "good": true,
             "characters": [
@@ -1173,6 +1274,7 @@
             "season": 5,
             "episode": 21,
             "description": "Grampa and Mr. Burns vie for Mrs. Bouvier's hand in marriage.  Bart purchases a worthless Itchy and Scratchy animation cell.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 305681987583,
             "good": false,
             "characters": []
@@ -1182,6 +1284,7 @@
             "season": 5,
             "episode": 22,
             "description": "Marge kicks Homer out of the house after she discovers that he revealed her personal secrets to an adult education class.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 279720003973,
             "good": true,
             "characters": [
@@ -1194,6 +1297,7 @@
             "season": 6,
             "episode": 1,
             "description": "Bart believes he witnessed Ned Flanders murder his wife.  Lisa's popularity soars after her family buys a swimming pool during a heat wave.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 300925507538,
             "good": true,
             "characters": [
@@ -1207,6 +1311,7 @@
             "season": 6,
             "episode": 2,
             "description": "Lisa becomes jealous when she meets a new student who is even more intelligent than herself.  Homer acquires a truckload of white sugar, thinking it will net him a fortune.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 278809667691,
             "good": false,
             "characters": [
@@ -1219,6 +1324,7 @@
             "season": 6,
             "episode": 3,
             "description": "When Marge suspects that romance has gone out of her life, her family recalls romantic encounters from their past.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 300928067775,
             "good": false,
             "characters": [
@@ -1230,6 +1336,7 @@
             "season": 6,
             "episode": 4,
             "description": "The Simpsons visit a theme park based on the gratuitously violent Itchy and Scratchy cartoons.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 283752003577,
             "good": true,
             "characters": [
@@ -1241,6 +1348,7 @@
             "season": 6,
             "episode": 5,
             "description": "Sideshow Bob runs for political office after Mayor Quimby pardons him from prison.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 275729987504,
             "good": true,
             "characters": [
@@ -1253,6 +1361,7 @@
             "season": 6,
             "episode": 6,
             "description": "The Simpsons spin three tales of Halloween horror.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 299597891663,
             "good": true,
             "characters": [
@@ -1264,6 +1373,7 @@
             "season": 6,
             "episode": 7,
             "description": "Bart falls in love with Reverend Lovejoy's beautiful daughter, only to discover that she is more of a hellion than he is.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 275744323759,
             "good": true,
             "characters": [
@@ -1275,6 +1385,7 @@
             "season": 6,
             "episode": 8,
             "description": "Lisa joins a hockey team and finds herself pitted against Bart in a critical game.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 275746371575,
             "good": true,
             "characters": [
@@ -1287,6 +1398,7 @@
             "season": 6,
             "episode": 9,
             "description": "Homer is wrongly accused of committing sexual harassment.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 275746883653,
             "good": true,
             "characters": [
@@ -1298,6 +1410,7 @@
             "season": 6,
             "episode": 10,
             "description": "While selling a homemade tonic guaranteed to increase sexual desire in men, Grampa reveals that Homer's conception was accidental.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 274264643876,
             "good": true,
             "characters": [
@@ -1310,6 +1423,7 @@
             "season": 6,
             "episode": 11,
             "description": "Marge seeks professional help from a psychiatrist after realizing she is afraid to fly.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 305684547546,
             "good": false,
             "characters": [
@@ -1321,6 +1435,7 @@
             "season": 6,
             "episode": 12,
             "description": "Homer's popularity skyrockets when he is chosen as the leader of a secret organization.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 275745859881,
             "good": true,
             "characters": [
@@ -1332,6 +1447,7 @@
             "season": 6,
             "episode": 13,
             "description": "Homer recounts how Maggie's accidental birth changed his life forever.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 278796867754,
             "good": false,
             "characters": []
@@ -1341,6 +1457,7 @@
             "season": 6,
             "episode": 14,
             "description": "Bart discovers a comet that is on a collision course with Springfield.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 275746883888,
             "good": true,
             "characters": [
@@ -1352,6 +1469,7 @@
             "season": 6,
             "episode": 15,
             "description": "Homer enrolls in a clown college franchised by Krusty the Clown.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 279723587611,
             "good": true,
             "characters": [
@@ -1364,6 +1482,7 @@
             "season": 6,
             "episode": 16,
             "description": "Bart must apologize to the country of Australia after he tricks a boy from down under into accepting an expensive collect call.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 275748931680,
             "good": true,
             "characters": [
@@ -1375,6 +1494,7 @@
             "season": 6,
             "episode": 17,
             "description": "Homer is forced to borrow money from Patty and Selma after he wipes out the family's savings by investing in pumpkins.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 305686083529,
             "good": true,
             "characters": [
@@ -1388,6 +1508,7 @@
             "season": 6,
             "episode": 18,
             "description": "Homer grows jealous after Marge asks critic Jay Sherman to co-judge Springfield's film festival.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 283753539580,
             "good": true,
             "characters": [
@@ -1400,6 +1521,7 @@
             "season": 6,
             "episode": 19,
             "description": "A fortune teller describes how a genteel Englishman will ask for Lisa's hand in marriage in the year 2010.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 275751491511,
             "good": false,
             "characters": [
@@ -1411,6 +1533,7 @@
             "season": 6,
             "episode": 20,
             "description": "Bart and Lisa attempt to rescue 25 greyhound puppies from Mr. Burns, who wants to use their hides for a new tuxedo.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 278807107855,
             "good": true,
             "characters": [
@@ -1424,6 +1547,7 @@
             "season": 6,
             "episode": 21,
             "description": "Bart masterminds a teacher's strike, but is humiliated when Marge takes charge of his class.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 294780995610,
             "good": true,
             "characters": [
@@ -1436,6 +1560,7 @@
             "season": 6,
             "episode": 22,
             "description": "Lisa is saddened by the death of blues great Bleeding Gums Murphy.  Bart ingests a piece of jagged metal while eating Krusty-O cereal.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 275755587777,
             "good": true,
             "characters": [
@@ -1449,6 +1574,7 @@
             "season": 6,
             "episode": 23,
             "description": "Marge joins the police force.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 305689155572,
             "good": true,
             "characters": [
@@ -1461,6 +1587,7 @@
             "season": 6,
             "episode": 24,
             "description": "Bart and his friends march on Shelbyville when Springfield's lemon tree is stolen by a gang of children from across the border.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 274269763684,
             "good": true,
             "characters": [
@@ -1473,6 +1600,7 @@
             "season": 6,
             "episode": 25,
             "description": "Just about everyone in Springfield vows to kill Mr. Burns after he cheats the elementary school out of a newly discovered oil well and threatens to block out the sun.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 294781507859,
             "good": true,
             "characters": [
@@ -1485,6 +1613,7 @@
             "season": 7,
             "episode": 1,
             "description": "Lisa aids police with the investigation of the Burns shooting.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 305689667892,
             "good": true,
             "characters": []
@@ -1494,6 +1623,7 @@
             "season": 7,
             "episode": 2,
             "description": "Hollywood producers cast Milhouse in a motion picture based on the popular \"Radioactive Man\" comic books.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 305693251940,
             "good": true,
             "characters": []
@@ -1503,6 +1633,7 @@
             "season": 7,
             "episode": 3,
             "description": "The Flanders gain custody of the Simpson children after welfare workers accuse Homer and Marge of being negligent parents.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 306174019869,
             "good": true,
             "characters": []
@@ -1512,6 +1643,7 @@
             "season": 7,
             "episode": 4,
             "description": "Bart sells his soul to Milhouse for five dollars.  Moe transforms his bar into a family restaurant.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 276972099995,
             "good": true,
             "characters": []
@@ -1521,6 +1653,7 @@
             "season": 7,
             "episode": 5,
             "description": "Lisa turns vegetarian after her family visits a petting zoo.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 276980291592,
             "good": true,
             "characters": []
@@ -1530,6 +1663,7 @@
             "season": 7,
             "episode": 6,
             "description": "The Simpsons appear in three horrifying Halloween tales.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 310404163601,
             "good": true,
             "characters": [
@@ -1541,6 +1675,7 @@
             "season": 7,
             "episode": 7,
             "description": "Homer intentionally gains weight so he can qualify for disability and work at home.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 294786627843,
             "good": true,
             "characters": []
@@ -1550,6 +1685,7 @@
             "season": 7,
             "episode": 8,
             "description": "After Homer fakes his own death, his long-thought-deceased mother arrives in Springfield to pay her last respects.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 276983875726,
             "good": true,
             "characters": []
@@ -1559,6 +1695,7 @@
             "season": 7,
             "episode": 9,
             "description": "Sideshow Bob threatens to detonate a nuclear bomb unless television is abolished.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 302792771516,
             "good": true,
             "characters": []
@@ -1568,6 +1705,7 @@
             "season": 7,
             "episode": 10,
             "description": "Troy McClure hosts this special 138th episode, which includes the first-ever cartoon shorts, trivia questions, and never-before-seen footage.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 324451395934,
             "good": true,
             "characters": []
@@ -1577,6 +1715,7 @@
             "season": 7,
             "episode": 11,
             "description": "As Christmas approaches, Marge treats Bart like an adult after he is caught shoplifting.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 305669699710,
             "good": true,
             "characters": []
@@ -1586,6 +1725,7 @@
             "season": 7,
             "episode": 12,
             "description": "Homer reluctantly accepts Mr. Burns into his new bowling league.  Bart causes a student riot by wearing a Mad magazine iron-on prompting Skinner to implement a school dress code.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 302792771967,
             "good": true,
             "characters": []
@@ -1595,6 +1735,7 @@
             "season": 7,
             "episode": 13,
             "description": "Former President George Bush and his wife Barbara buy a house across the street from the Simpsons.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 276994115834,
             "good": true,
             "characters": []
@@ -1604,6 +1745,7 @@
             "season": 7,
             "episode": 14,
             "description": "The Simpsons apply for membership at a posh country club.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 305694276001,
             "good": true,
             "characters": []
@@ -1613,6 +1755,7 @@
             "season": 7,
             "episode": 15,
             "description": "Krusty is arrested for massive tax fraud after Bart inadvertently exposes his hero's illegal bank account.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 301346371709,
             "good": true,
             "characters": []
@@ -1622,6 +1765,7 @@
             "season": 7,
             "episode": 16,
             "description": "Lisa discovers that Jebediah Springfield was a vicious pirate. Homer wins the coveted role of town crier in an upcoming parade.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 302796355658,
             "good": true,
             "characters": []
@@ -1631,6 +1775,7 @@
             "season": 7,
             "episode": 17,
             "description": "Homer acts as Mr. Burns' assistant while Smithers is away on vacation.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 277248579634,
             "good": true,
             "characters": []
@@ -1640,6 +1785,7 @@
             "season": 7,
             "episode": 18,
             "description": "Bart and Lisa come to the aid of a down-and-out man who claims to have invented the concept of cartoon violence.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 301668931982,
             "good": true,
             "characters": []
@@ -1649,6 +1795,7 @@
             "season": 7,
             "episode": 19,
             "description": "Troy McClure stages a Hollywood comeback when he begins dating Selma.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 300935235544,
             "good": true,
             "characters": []
@@ -1658,6 +1805,7 @@
             "season": 7,
             "episode": 20,
             "description": "Using a fake driver's license, Bart rents a car and embarks on a Spring Break road trip with his friends.  A special bond develops between Lisa and Homer after Skinner invents Go To Work With Your Parents Day.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 277000259951,
             "good": true,
             "characters": []
@@ -1667,6 +1815,7 @@
             "season": 7,
             "episode": 21,
             "description": "The lives of Springfield residents are highlighted in a series of interconnecting vignettes.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 299588163608,
             "good": true,
             "characters": []
@@ -1676,6 +1825,7 @@
             "season": 7,
             "episode": 22,
             "description": "Grampa and Mr. Burns, the last surviving members of a World War II army unit, vie for a priceless collection of rare art hidden in a secret location.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 279728707597,
             "good": true,
             "characters": []
@@ -1685,6 +1835,7 @@
             "season": 7,
             "episode": 23,
             "description": "Apu faces deportation when a referendum on illegal immigrants is placed on the Springfield ballot.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 310404675978,
             "good": true,
             "characters": []
@@ -1694,6 +1845,7 @@
             "season": 7,
             "episode": 24,
             "description": "Homer is hired to perform in a rock festival.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 277008451637,
             "good": true,
             "characters": []
@@ -1703,6 +1855,7 @@
             "season": 7,
             "episode": 25,
             "description": "While on summer vacation with her family, Lisa sheds her nerdy image in an effort to make new friends.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 277013571573,
             "good": true,
             "characters": []
@@ -1712,6 +1865,7 @@
             "season": 8,
             "episode": 1,
             "description": "The Simpsons appear in three tales of terror: Bart discovers an evil twin brother living in the attic; Lisa creates a microscopic society; and space aliens transform themselves into Clinton and Dole look-alikes.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 299625027835,
             "good": true,
             "characters": [
@@ -1723,6 +1877,7 @@
             "season": 8,
             "episode": 2,
             "description": "The Simpsons relocate to another community after Homer unwittingly takes a job with a company controlled by a super-villain.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 306390595776,
             "good": true,
             "characters": []
@@ -1732,6 +1887,7 @@
             "season": 8,
             "episode": 3,
             "description": "Homer becomes a professional boxer when doctors discover he was born with a unique genetic condition that protects his brain from injury.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 288058947803,
             "good": true,
             "characters": []
@@ -1741,6 +1897,7 @@
             "season": 8,
             "episode": 4,
             "description": "With Homer's help, Mr. Burns' long-lost son stages his own kidnapping.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 299622467514,
             "good": false,
             "characters": []
@@ -1750,6 +1907,7 @@
             "season": 8,
             "episode": 5,
             "description": "While Marge is out of town, Homer allows Bart to work at a burlesque house.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 294789699801,
             "good": true,
             "characters": []
@@ -1759,6 +1917,7 @@
             "season": 8,
             "episode": 6,
             "description": "When Milhouse's parents get a divorce, Homer grows convinced that his own marriage is in jeopardy.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 277025347786,
             "good": true,
             "characters": []
@@ -1768,6 +1927,7 @@
             "season": 8,
             "episode": 7,
             "description": "Lisa develops a crush on bully Nelson Muntz.  Homer uses an automatic telephone dialer for an electronic panhandling scheme.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 306394691862,
             "good": true,
             "characters": []
@@ -1777,6 +1937,7 @@
             "season": 8,
             "episode": 8,
             "description": "Ned Flanders suffers a breakdown after his home is destroyed by a hurricane.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 436250179702,
             "good": true,
             "characters": []
@@ -1786,6 +1947,7 @@
             "season": 8,
             "episode": 9,
             "description": "After ingesting several Guatemalan peppers during chili cook-off, Homer experiences hallucinatory visions that inspire him to find his true soul mate in life.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 436252739905,
             "good": true,
             "characters": []
@@ -1795,6 +1957,7 @@
             "season": 8,
             "episode": 10,
             "description": "X-Files Agents Mulder and Scully investigate Homer's encounter with an alleged extraterrestrial.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 436259395954,
             "good": true,
             "characters": []
@@ -1804,6 +1967,7 @@
             "season": 8,
             "episode": 11,
             "description": "After being expelled from an investment club, Marge starts her own pretzel franchise.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 436264515927,
             "good": true,
             "characters": []
@@ -1813,6 +1977,7 @@
             "season": 8,
             "episode": 12,
             "description": "Homer and Mr. Burns are buried beneath an avalanche during a survival trek in the mountains.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 436267075791,
             "good": true,
             "characters": []
@@ -1822,6 +1987,7 @@
             "season": 8,
             "episode": 13,
             "description": "The Simpsons hire a Mary Poppins-like nanny when Marge becomes overwhelmed by the demands of being a housewife.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 436271683676,
             "good": true,
             "characters": []
@@ -1831,6 +1997,7 @@
             "season": 8,
             "episode": 14,
             "description": "When ratings for Itchy & Scratchy cartoons plummet, a studio committee creates a new, hipper character and hires Homer to provide the voice. Presented by FXX.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 436278339668,
             "good": true,
             "characters": []
@@ -1840,6 +2007,7 @@
             "season": 8,
             "episode": 15,
             "description": "Homer grows homophobic after he realizes the family's new friend is gay.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 436284995621,
             "good": true,
             "characters": []
@@ -1849,6 +2017,7 @@
             "season": 8,
             "episode": 16,
             "description": "Bart fears the worst when Sideshow Bob wins release from prison by claiming he is a reformed man and is hired by his brother to work on a construction project.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 436296259771,
             "good": true,
             "characters": []
@@ -1858,6 +2027,7 @@
             "season": 8,
             "episode": 17,
             "description": "Homer and Marge allow Lisa to baby-sit Bart.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 436301891875,
             "good": false,
             "characters": []
@@ -1867,6 +2037,7 @@
             "season": 8,
             "episode": 18,
             "description": "Homer turns bootlegger when Springfield enforces an antiquated prohibition law.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 436402755605,
             "good": true,
             "characters": []
@@ -1876,6 +2047,7 @@
             "season": 8,
             "episode": 19,
             "description": "Bart exposes Skinner and Krabappel's clandestine affair.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 436412995642,
             "good": true,
             "characters": []
@@ -1885,6 +2057,7 @@
             "season": 8,
             "episode": 20,
             "description": "Bart gives away Santa's Little Helper so he can keep a fully trained, blue ribbon Collie.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 436370499586,
             "good": false,
             "characters": []
@@ -1894,6 +2067,7 @@
             "season": 8,
             "episode": 21,
             "description": "Lisa helps Mr. Burns build a recycling center after a series of bad investments costs the multimillionaire his fortune.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 436383811985,
             "good": true,
             "characters": []
@@ -1903,6 +2077,7 @@
             "season": 8,
             "episode": 22,
             "description": "Marge becomes a church volunteer.  Homer discovers his image printed on a box of Japanese dish detergent.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 436438595644,
             "good": true,
             "characters": []
@@ -1912,6 +2087,7 @@
             "season": 8,
             "episode": 23,
             "description": "A resentful, hard-working employee at the power plant makes Homer his enemy.  Bart purchases an abandoned factory for one dollar at a government auction.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 436466755640,
             "good": true,
             "characters": []
@@ -1921,6 +2097,7 @@
             "season": 8,
             "episode": 24,
             "description": "Troy McClure hosts three spin-offs from \"The Simpsons\" television show.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 436481091875,
             "good": false,
             "characters": []
@@ -1930,6 +2107,7 @@
             "season": 8,
             "episode": 25,
             "description": "Cadets give Lisa the \"silent treatment\" when she enrolls in an all-male military academy.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 1071844931909,
             "good": true,
             "characters": []
@@ -1939,6 +2117,7 @@
             "season": 9,
             "episode": 1,
             "description": "The Simpsons journey to New York City to retrieve the family car.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 436516931611,
             "good": true,
             "characters": []
@@ -1948,6 +2127,7 @@
             "season": 9,
             "episode": 2,
             "description": "A stranger claims that Principal Skinner is an impostor.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 436505155662,
             "good": true,
             "characters": []
@@ -1957,6 +2137,7 @@
             "season": 9,
             "episode": 3,
             "description": "Homer and Marge recount how Lisa got her saxophone.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 279743555749,
             "good": false,
             "characters": []
@@ -1966,6 +2147,7 @@
             "season": 9,
             "episode": 4,
             "description": "Homer battles killer mutants after Springfield is destroyed by a nuclear blast; a matter- transportation device melds Bart with a housefly; in Colonial times, Marge is accused of being a witch.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 279170627965,
             "good": true,
             "characters": [
@@ -1977,6 +2159,7 @@
             "season": 9,
             "episode": 5,
             "description": "Homer purchases a handgun to protect his family.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 302813251779,
             "good": true,
             "characters": []
@@ -1986,6 +2169,7 @@
             "season": 9,
             "episode": 6,
             "description": "Homer becomes coach of the Springfield Pee Wee Football team and appoints Bart as starting quarterback.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 448293443714,
             "good": false,
             "characters": []
@@ -1995,6 +2179,7 @@
             "season": 9,
             "episode": 7,
             "description": "In an effort to annul an arranged marriage, Apu tells his mother he wed Marge.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 279177283545,
             "good": false,
             "characters": []
@@ -2004,6 +2189,7 @@
             "season": 9,
             "episode": 8,
             "description": "Townspeople believe Lisa has unearthed the fossilized remains of an angel.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 279180355540,
             "good": true,
             "characters": []
@@ -2013,6 +2199,7 @@
             "season": 9,
             "episode": 9,
             "description": "Marge gets a job with a realty firm, but her honesty costs her lucrative sales.  Homer purchases a 60s hot-rod convertible at a police auction.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 280404547525,
             "good": true,
             "characters": []
@@ -2022,6 +2209,7 @@
             "season": 9,
             "episode": 10,
             "description": "People throughout Springfield open their hearts and wallets after Bart claims the family's Christmas presents were stolen by a burglar.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 306881091696,
             "good": false,
             "characters": []
@@ -2031,6 +2219,7 @@
             "season": 9,
             "episode": 11,
             "description": "The Simpsons recall their many musical moments from seasons past.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 294808131518,
             "good": false,
             "characters": []
@@ -2040,6 +2229,7 @@
             "season": 9,
             "episode": 12,
             "description": "A carnival worker and his son move in with the Simpsons after Homer costs them their jobs.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 302818371931,
             "good": true,
             "characters": []
@@ -2049,6 +2239,7 @@
             "season": 9,
             "episode": 13,
             "description": "Marge tries her hand at deprogramming after her family is brainwashed by a religious cult.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 299627075941,
             "good": true,
             "characters": []
@@ -2058,6 +2249,7 @@
             "season": 9,
             "episode": 14,
             "description": "Bart, Lisa and their classmates fight for survival when they become stranded on a remote island.  Homer starts his own business on the Internet.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 448356931860,
             "good": false,
             "characters": []
@@ -2067,6 +2259,7 @@
             "season": 9,
             "episode": 15,
             "description": "Krusty shuns his old routines in favor of edgier material and suddenly becomes the hottest comic in show business.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 294812739638,
             "good": true,
             "characters": []
@@ -2076,6 +2269,7 @@
             "season": 9,
             "episode": 16,
             "description": "When Moe goes broke romancing his new love, he enlists Homer in a scheme to collect on an insurance policy.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 283910211639,
             "good": true,
             "characters": []
@@ -2085,6 +2279,7 @@
             "season": 9,
             "episode": 17,
             "description": "Lisa fears she is genetically predisposed to lose her intelligence. Apu uses a frozen Jasper as a tourist attraction.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 299651139676,
             "good": true,
             "characters": []
@@ -2094,6 +2289,7 @@
             "season": 9,
             "episode": 18,
             "description": "Bart is appalled when Marge pairs him with Ralph Wiggum.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 299639875678,
             "good": false,
             "characters": []
@@ -2103,6 +2299,7 @@
             "season": 9,
             "episode": 19,
             "description": "Homer becomes the captain of a Navy submarine.  Bart gets his ear pierced.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 302809667837,
             "good": true,
             "characters": []
@@ -2112,6 +2309,7 @@
             "season": 9,
             "episode": 20,
             "description": "When a tax audit lands him in hot water, Homer goes undercover for the government and attempts to retrieve a trillion dollar note from Mr. Burns.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 299644483816,
             "good": false,
             "characters": []
@@ -2121,6 +2319,7 @@
             "season": 9,
             "episode": 21,
             "description": "Bart attempts to upstage Lisa when the pair co-host a children's news program.  Homer obtains a helper monkey.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 299672131928,
             "good": true,
             "characters": []
@@ -2130,6 +2329,7 @@
             "season": 9,
             "episode": 22,
             "description": "Homer enters the race for Sanitation Commissioner after garbage men refuse to collect his trash.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 307101763818,
             "good": true,
             "characters": []
@@ -2139,6 +2339,7 @@
             "season": 9,
             "episode": 23,
             "description": "After improving his physique, Homer attempts to climb a treacherous mountain.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 467593795648,
             "good": false,
             "characters": []
@@ -2148,6 +2349,7 @@
             "season": 9,
             "episode": 24,
             "description": "Lisa gets lost in an unfamiliar part of town while searching for a museum. Bart adheres novelties to his face only to discover they cannot be removed.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 467595331852,
             "good": true,
             "characters": []
@@ -2157,6 +2359,7 @@
             "season": 9,
             "episode": 25,
             "description": "Homer and Marge discover the secret to reigniting their sex life. Bart and Lisa hunt for hidden treasure using Grampa's old mine sweeper.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 467599939876,
             "good": false,
             "characters": []
@@ -2166,6 +2369,7 @@
             "season": 10,
             "episode": 1,
             "description": "Homer thinks he can net a fortune by recycling grease.  Lisa helps organize a school dance.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 292933187533,
             "good": true,
             "characters": []
@@ -2175,6 +2379,7 @@
             "season": 10,
             "episode": 2,
             "description": "After realizing half his life is over, Homer decides to become the next Thomas Edison.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 473117763575,
             "good": true,
             "characters": []
@@ -2184,6 +2389,7 @@
             "season": 10,
             "episode": 3,
             "description": "Bart tends to a nest filled with eggs after he inadvertently kills a bird with a BB gun.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 473109571557,
             "good": true,
             "characters": []
@@ -2193,6 +2399,7 @@
             "season": 10,
             "episode": 4,
             "description": "An evil toupee possesses Homer; Bart and Lisa find themselves trapped inside an Itchy & Scratchy cartoon; baby Maggie turns out to be the daughter of a space alien.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 473130051681,
             "good": true,
             "characters": [
@@ -2204,6 +2411,7 @@
             "season": 10,
             "episode": 5,
             "description": "Homer befriends a group of Hollywood celebrities vacationing in a remote part of town and promises to keep their whereabouts a secret.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 473147459674,
             "good": false,
             "characters": []
@@ -2213,6 +2421,7 @@
             "season": 10,
             "episode": 6,
             "description": "Homer embraces his newly discovered hippie heritage.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 473138243754,
             "good": false,
             "characters": []
@@ -2222,6 +2431,7 @@
             "season": 10,
             "episode": 7,
             "description": "Lisa suffers a guilty conscience after she cheats on an exam.  Homer believes he will save a fortune by raising his own lobster.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 473152579638,
             "good": true,
             "characters": []
@@ -2231,6 +2441,7 @@
             "season": 10,
             "episode": 8,
             "description": "Homer offers to donate one of his kidneys to Grampa until he realizes the surgery will place his own life in jeopardy.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 473158211896,
             "good": false,
             "characters": []
@@ -2240,6 +2451,7 @@
             "season": 10,
             "episode": 9,
             "description": "Homer takes on the mob when he acts as Mayor Quimby's bodyguard.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 473163843671,
             "good": true,
             "characters": []
@@ -2249,6 +2461,7 @@
             "season": 10,
             "episode": 10,
             "description": "Homer shows Flanders how to enjoy life by taking him to Las Vegas.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 473115203586,
             "good": false,
             "characters": []
@@ -2258,6 +2471,7 @@
             "season": 10,
             "episode": 11,
             "description": "The children of Springfield rebel after Wiggum enforces a curfew.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 473155651508,
             "good": true,
             "characters": []
@@ -2267,6 +2481,7 @@
             "season": 10,
             "episode": 12,
             "description": "Homer and his friends eagerly anticipate attending the Super Bowl until a ticketing snafu threatens to keep them from seeing the game.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 473132611959,
             "good": false,
             "characters": []
@@ -2276,6 +2491,7 @@
             "season": 10,
             "episode": 13,
             "description": "Homer changes his name when a dimwitted television show character named \"Homer Simpson\" becomes an overnight sensation.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 473140803870,
             "good": false,
             "characters": []
@@ -2285,6 +2501,7 @@
             "season": 10,
             "episode": 14,
             "description": "Apu showers his wife with Valentine's Day surprises making men throughout Springfield look like cheapskates.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 473104963819,
             "good": true,
             "characters": []
@@ -2294,6 +2511,7 @@
             "season": 10,
             "episode": 15,
             "description": "Marge discovers the pleasures of driving a sport utility vehicle until aggressive highway habits cost her.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 473097795997,
             "good": true,
             "characters": []
@@ -2303,6 +2521,7 @@
             "season": 10,
             "episode": 16,
             "description": "Lisa exhibits signs of stress when she is forced into sharing her brother's bedroom.  Marge becomes addicted to eavesdropping on cellular phone conversations.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 473093187636,
             "good": false,
             "characters": []
@@ -2312,6 +2531,7 @@
             "season": 10,
             "episode": 17,
             "description": "Homer and Bart attempt to deliver a dead trucker's cargo on schedule.  Meanwhile, Marge decides to have an adventure of her own and purchases a new doorbell.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 473095235738,
             "good": true,
             "characters": []
@@ -2321,6 +2541,7 @@
             "season": 10,
             "episode": 18,
             "description": "While listening to one of Reverend Lovejoy's sermons on a sweltering Easter Sunday morning, the Simpsons fall asleep and envision themselves as characters from the Bible.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 299678275566,
             "good": false,
             "characters": []
@@ -2330,6 +2551,7 @@
             "season": 10,
             "episode": 19,
             "description": "Homer pursues a career as an artist when his misshapen barbecue pit attracts the attention of a gallery.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 310457411688,
             "good": true,
             "characters": []
@@ -2339,6 +2561,7 @@
             "season": 10,
             "episode": 20,
             "description": "Bart must perform community service at Grampa's retirement home.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 279757379586,
             "good": true,
             "characters": []
@@ -2348,6 +2571,7 @@
             "season": 10,
             "episode": 21,
             "description": "Mr. Burns attempts to win adoration by transporting the Loch Ness monster to Springfield.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 310427203648,
             "good": false,
             "characters": []
@@ -2357,6 +2581,7 @@
             "season": 10,
             "episode": 22,
             "description": "Lisa is invited to join Mensa; Homer receives a free erotic photo session.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 306868803826,
             "good": false,
             "characters": []
@@ -2366,6 +2591,7 @@
             "season": 10,
             "episode": 23,
             "description": "The Simpsons board a mega-saver flight for Tokyo, only to find themselves trapped overseas when they run out of money.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 306901571847,
             "good": true,
             "characters": []
@@ -2375,6 +2601,7 @@
             "season": 11,
             "episode": 1,
             "description": "Studio executives panic when actor Mel Gibson taps Homer to help him retool his latest film.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 306906179700,
             "good": true,
             "characters": [
@@ -2386,6 +2613,7 @@
             "season": 11,
             "episode": 2,
             "description": "Bart is diagnosed with Attention Deficit Disorder and placed on medication that quells his disruptive behavior.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 302833219678,
             "good": false,
             "characters": [
@@ -2397,6 +2625,7 @@
             "season": 11,
             "episode": 3,
             "description": "Homer becomes the Springfield Shopper's new food critic, but raises the ire of restaurateurs by panning their cooking.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 306911811691,
             "good": true,
             "characters": [
@@ -2408,6 +2637,7 @@
             "season": 11,
             "episode": 4,
             "description": "Homer's Y2K error plunges the Earth into chaos; Bart and Lisa become superheroes and attempt to save Lucy Lawless from a super-villain; someone terrorizes the family after Marge kills Ned Flanders.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 307851843709,
             "good": true,
             "characters": [
@@ -2419,6 +2649,7 @@
             "season": 11,
             "episode": 5,
             "description": "The Simpsons relocate to a farm, where Homer produces a tomato that is highly addictive.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 302847555697,
             "good": true,
             "characters": []
@@ -2428,6 +2659,7 @@
             "season": 11,
             "episode": 6,
             "description": "Homer becomes an instant celebrity when he bowls a perfect game.  But when his fame fades away, he lavishes his time on baby Maggie.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 294762563857,
             "good": true,
             "characters": [
@@ -2440,6 +2672,7 @@
             "season": 11,
             "episode": 7,
             "description": "Apu is driven to the brink when his wife, Manjula, gives birth to octuplets.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 306920003903,
             "good": false,
             "characters": [
@@ -2451,6 +2684,7 @@
             "season": 11,
             "episode": 8,
             "description": "Homer wins a vintage motorcycle during a dance contest - and attracts the attention of Hell's Satans when he forms his own gang.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 301643843522,
             "good": true,
             "characters": [
@@ -2463,6 +2697,7 @@
             "season": 11,
             "episode": 9,
             "description": "As the Christmas holiday approaches... Springfield Elementary closes its doors for financial reasons, only to reopen when a mysterious organization steps in to help.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 848995395938,
             "good": false,
             "characters": [
@@ -2475,6 +2710,7 @@
             "season": 11,
             "episode": 10,
             "description": "Lisa becomes mother-of-the-house when Marge is hospitalized with a broken leg.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 300903491898,
             "good": true,
             "characters": []
@@ -2484,6 +2720,7 @@
             "season": 11,
             "episode": 11,
             "description": "Bart believes he has the power to heal the sick.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 300909123775,
             "good": false,
             "characters": []
@@ -2493,6 +2730,7 @@
             "season": 11,
             "episode": 12,
             "description": "The Simpsons care for Burns' mansion when the billionaire leaves town for a medical exam.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 279747651734,
             "good": true,
             "characters": [
@@ -2505,6 +2743,7 @@
             "season": 11,
             "episode": 13,
             "description": "When Homer and Bart transform a loser racehorse into a champion, rival jockeys threaten revenge.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 306926659533,
             "good": false,
             "characters": [
@@ -2517,6 +2756,7 @@
             "season": 11,
             "episode": 14,
             "description": "Homer attempts to help when Flanders experiences a tragic loss.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 288077891629,
             "good": false,
             "characters": [
@@ -2529,6 +2769,7 @@
             "season": 11,
             "episode": 15,
             "description": "Homer is forced to become a missionary on a remote island after he pledges a large sum of money to PBS.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 310458435665,
             "good": false,
             "characters": [
@@ -2540,6 +2781,7 @@
             "season": 11,
             "episode": 16,
             "description": "Moe undergoes plastic surgery and becomes a hot new soap opera star.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 294758467783,
             "good": false,
             "characters": [
@@ -2551,6 +2793,7 @@
             "season": 11,
             "episode": 17,
             "description": "A Native American casino manager shows Bart a glimpse into the future... a time when Bart is an over-the-hill moocher and Lisa is President of the United States.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 302835267686,
             "good": true,
             "characters": [
@@ -2563,6 +2806,7 @@
             "season": 11,
             "episode": 18,
             "description": "Barney swears off alcohol, creating a rift between he and Homer; seeking to win a contest, Bart and Lisa attempt to photograph a new cover for the Springfield phone book.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 306930755636,
             "good": false,
             "characters": [
@@ -2575,6 +2819,7 @@
             "season": 11,
             "episode": 19,
             "description": "The Simpsons find themselves on the run from the law after they accidentally kill a beloved alligator while vacationing in Florida.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 292935747924,
             "good": false,
             "characters": [
@@ -2586,6 +2831,7 @@
             "season": 11,
             "episode": 20,
             "description": "After watching a movie about a sexy tango dancer, Lisa enrolls in a tap dance class... only to discover she has two left feet; Bart and Milhouse abandon a camping trip and hide out in a shopping mall.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 302849091512,
             "good": true,
             "characters": [
@@ -2599,6 +2845,7 @@
             "season": 11,
             "episode": 21,
             "description": "When Otto ditches his fianc\u00e9e at the altar, Bart invites her to stay with the family... forcing Marge to compete with the much younger woman.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 301683779737,
             "good": true,
             "characters": [
@@ -2610,6 +2857,7 @@
             "season": 11,
             "episode": 22,
             "description": "This 'behind-the-scenes' special chronicles the ups and downs of America's favorite sitcom family.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 279751747780,
             "good": true,
             "characters": [
@@ -2621,6 +2869,7 @@
             "season": 12,
             "episode": 1,
             "description": "On Halloween... a deceased Homer must perform one good deed to get into heaven; angry dolphins launch an attack against the people of Springfield; Bart and Lisa encounter characters from fairy tales.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 294765123660,
             "good": false,
             "characters": [
@@ -2632,6 +2881,7 @@
             "season": 12,
             "episode": 2,
             "description": "The townspeople of Springfield divide into two communities when the telephone company institutes a new area code system.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 300911171880,
             "good": true,
             "characters": [
@@ -2643,6 +2893,7 @@
             "season": 12,
             "episode": 3,
             "description": "Krusty discovers that he fathered a child during the Gulf War... only to gamble away his daughter's precious violin during a poker game with Fat Tony.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 306934851515,
             "good": false,
             "characters": [
@@ -2654,6 +2905,7 @@
             "season": 12,
             "episode": 4,
             "description": "Lisa joins a group of eco-radicals in her attempt to save the city's oldest redwood tree.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 306939971530,
             "good": false,
             "characters": [
@@ -2665,6 +2917,7 @@
             "season": 12,
             "episode": 5,
             "description": "As the Thanksgiving holiday approaches, Mr. Burns hires Homer to be his 'prank monkey.'",
+            "disneyplus_id": null,
             "simpsonsworld_id": 311670339999,
             "good": false,
             "characters": [
@@ -2677,6 +2930,7 @@
             "season": 12,
             "episode": 6,
             "description": "Homer uses his new computer to spread gossip on the Internet... and eventually finds himself stranded on a mysterious island.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 302843971598,
             "good": false,
             "characters": [
@@ -2688,6 +2942,7 @@
             "season": 12,
             "episode": 7,
             "description": "Homer and Bart become scam artists when the family is faced with the cost of a sudden car repair.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 304456259863,
             "good": true,
             "characters": [
@@ -2700,6 +2955,7 @@
             "season": 12,
             "episode": 8,
             "description": "As Christmas approaches, a winter snowstorm traps Bart, Lisa and their fellow students inside Springfield Elementary, where Principal Skinner attempts to keep chaos from erupting.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 307850819951,
             "good": false,
             "characters": [
@@ -2713,6 +2969,7 @@
             "season": 12,
             "episode": 9,
             "description": "Homer experiences a dramatic increase in intelligence when researchers remove a crayon lodged in his brain.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 306945603638,
             "good": true,
             "characters": [
@@ -2725,6 +2982,7 @@
             "season": 12,
             "episode": 10,
             "description": "With Marge's help, an inmate with artistic ability is paroled from prison.  But when the ex-con gets a job painting a mural at the elementary school, he clashes with Skinner.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 302844995961,
             "good": false,
             "characters": [
@@ -2737,6 +2995,7 @@
             "season": 12,
             "episode": 11,
             "description": "When the Comic Book Guy suffers a heart attack, Bart and Milhouse take over his store.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 310459971509,
             "good": true,
             "characters": [
@@ -2750,6 +3009,7 @@
             "season": 12,
             "episode": 12,
             "description": "When the Simpsons construct a tennis court in the backyard, Bart pairs up with Marge and becomes a tennis whiz... much to Homer's disappointment.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 300916291603,
             "good": false,
             "characters": [
@@ -2763,6 +3023,7 @@
             "season": 12,
             "episode": 13,
             "description": "Sideshow Bob wins release from prison and hypnotizes Bart to kill Krusty the Clown.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 307106883649,
             "good": false,
             "characters": [
@@ -2776,6 +3037,7 @@
             "season": 12,
             "episode": 14,
             "description": "After casting Bart and his friends as singers in an all-boy band, a crazed record producer launches an attack on the offices of MAD magazine.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 310437443723,
             "good": true,
             "characters": [
@@ -2787,6 +3049,7 @@
             "season": 12,
             "episode": 15,
             "description": "Homer goes on a hunger strike after learning that the owner of the Springfield Isotopes plans on moving the team to Albuquerque.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 307850819931,
             "good": true,
             "characters": [
@@ -2798,6 +3061,7 @@
             "season": 12,
             "episode": 16,
             "description": "Lisa searches for answers when a new student at school bullies her; Homer starts his own baby-proofing business.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 302846019892,
             "good": false,
             "characters": [
@@ -2810,6 +3074,7 @@
             "season": 12,
             "episode": 17,
             "description": "The Simpsons journey through Africa, where they encounter jungle animals, tribesmen... and a chimp refuge owner with a secret.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 302845507908,
             "good": false,
             "characters": [
@@ -2821,6 +3086,7 @@
             "season": 12,
             "episode": 18,
             "description": "A day in the life of the Simpsons replays three times: Homer panics when Marge slices off his thumb; Lisa attempts to place her entry in the school science fair; Bart is pursued by gangsters.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 302842947994,
             "good": false,
             "characters": [
@@ -2833,6 +3099,7 @@
             "season": 12,
             "episode": 19,
             "description": "To fulfill his dead wife's final wish, Ned Flanders converts an old, closed amusement park into a new Christian amusement park, 'Praiseland.'  The park flops until visitors begin having 'visions.'",
+            "disneyplus_id": null,
             "simpsonsworld_id": 302848579632,
             "good": true,
             "characters": [
@@ -2844,6 +3111,7 @@
             "season": 12,
             "episode": 20,
             "description": "After Homer injures his knee, he's housebound for recuperation.  A successful stint as a babysitter prompts Homer to open a full-time daycare service, leaving Bart and Lisa feeling neglected.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 301652547508,
             "good": false,
             "characters": [
@@ -2855,6 +3123,7 @@
             "season": 12,
             "episode": 21,
             "description": "The Simpsons jump a train, and meet a hobo, who tells them twisted versions of three classic tales, all of which feature Simpsons characters.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 301685315594,
             "good": false,
             "characters": [
@@ -2866,6 +3135,7 @@
             "season": 13,
             "episode": 1,
             "description": "On Halloween, the Simpsons are menaced by a computer controlling an automated house; a gypsy curses Homer; Lisa and Bart find themselves in a Harry Potter-like adventure.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 307115075729,
             "good": false,
             "characters": [
@@ -2877,6 +3147,7 @@
             "season": 13,
             "episode": 2,
             "description": "A stern judge rules that Homer and Bart are to be tethered together, and later, Homer and Marge are declared bad parents and placed in old-fashioned wooden stocks.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 307116099877,
             "good": false,
             "characters": []
@@ -2886,6 +3157,7 @@
             "season": 13,
             "episode": 3,
             "description": "Moe turns the bar into a pretentious hang-out for Springfield's 'beautiful people,' forcing Homer to start a bar of his own inside his garage.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 300917827935,
             "good": false,
             "characters": [
@@ -2898,6 +3170,7 @@
             "season": 13,
             "episode": 4,
             "description": "When Mr. Burns falls for an attractive traffic cop many years his junior, he enlists Homer's help in romancing her.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 301344323882,
             "good": false,
             "characters": [
@@ -2910,6 +3183,7 @@
             "season": 13,
             "episode": 5,
             "description": "When placed under hypnosis, Homer struggles with a repressed memory-which leads to a shocking discovery.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 302898755902,
             "good": false,
             "characters": [
@@ -2921,6 +3195,7 @@
             "season": 13,
             "episode": 6,
             "description": "As Christmas approaches... Lisa searches for a new religion after Mr. Burns takes over her church and runs it like a corporation.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 288120899968,
             "good": true,
             "characters": [
@@ -2932,6 +3207,7 @@
             "season": 13,
             "episode": 7,
             "description": "A social worker attempts to transform the family into a functional, cooperative unit... until Homer's other wife shows up unexpectedly.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 283083843778,
             "good": false,
             "characters": [
@@ -2944,6 +3220,7 @@
             "season": 13,
             "episode": 8,
             "description": "After Springfield wins the title of World's Fattest Town, Marge launches an anti-sugar crusade, and sugar is banned from the city.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 302893635523,
             "good": false,
             "characters": [
@@ -2955,6 +3232,7 @@
             "season": 13,
             "episode": 9,
             "description": "When Homer has to have his jaw wired shut, he discovers the joys of listening, but Marge finds that a well-behaved Homer isn't what she really wanted.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 310440003514,
             "good": true,
             "characters": [
@@ -2967,6 +3245,7 @@
             "season": 13,
             "episode": 10,
             "description": "Marge's ex-boyfriend, now one of the world's richest men, offers Homer a million dollars in exchange for a weekend with her, to see what 'might have been.'",
+            "disneyplus_id": null,
             "simpsonsworld_id": 301684803770,
             "good": false,
             "characters": [
@@ -2979,6 +3258,7 @@
             "season": 13,
             "episode": 11,
             "description": "Bart travels to Canada to win back the heart of Rainier Wolfcastle's daughter after she runs off with Milhouse.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 307122755675,
             "good": false,
             "characters": [
@@ -2991,6 +3271,7 @@
             "season": 13,
             "episode": 12,
             "description": "Bart befriends an aging movie cowboy who begins drinking heavily when asked to appear on Krusty's television show.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 302899267542,
             "good": false,
             "characters": [
@@ -3002,6 +3283,7 @@
             "season": 13,
             "episode": 13,
             "description": "In an effort to win a date with a beautiful new resident at the nursing home, Grampa gets his driver's license back... and gives chase when the object of his affection leaves for Branson, Missouri.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 301659203973,
             "good": false,
             "characters": [
@@ -3013,6 +3295,7 @@
             "season": 13,
             "episode": 14,
             "description": "The Simpsons appear as characters in three classic tales: Homer as Odysseus leads the Greek army; Bart as Hamlet attempts to avenge the death of his father; Lisa as Joan of Arc pits the French against the English.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 310411843752,
             "good": false,
             "characters": [
@@ -3024,6 +3307,7 @@
             "season": 13,
             "episode": 15,
             "description": "When the Simpsons fly to Brazil to locate a missing orphan that Lisa has been sponsoring, Homer ends up getting kidnapped.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 301665347899,
             "good": false,
             "characters": [
@@ -3035,6 +3319,7 @@
             "season": 13,
             "episode": 16,
             "description": "When Homer is attacked by crows, he's prescribed medical marijuana to help relieve the pain... leading Burns to promote his happy employee to executive vice president of the power plant.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 310448195762,
             "good": true,
             "characters": [
@@ -3047,6 +3332,7 @@
             "season": 13,
             "episode": 17,
             "description": "Homer is roasted at the Springfield Friar's Club, leading to recollections from the past.  But the fate of the Earth hangs in the balance when aliens Kang and Kodos make an unexpected appearance.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 302888515845,
             "good": false,
             "characters": [
@@ -3058,6 +3344,7 @@
             "season": 13,
             "episode": 18,
             "description": "Bart launches a comic book with an angry Homer as the main character, and when it proves a huge success, Homer vows to give up getting angry for Lent.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 302883907921,
             "good": true,
             "characters": [
@@ -3070,6 +3357,7 @@
             "season": 13,
             "episode": 19,
             "description": "When Manjula kicks Apu out of the house for cheating on her, Homer and Marge search for a way to reunite the couple.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 288131139601,
             "good": false,
             "characters": [
@@ -3082,6 +3370,7 @@
             "season": 13,
             "episode": 20,
             "description": "Lisa is overjoyed when she befriends some college students; Bart becomes a boy-in-a-plastic-bubble after he's bitten by a Chinese mosquito.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 310416963509,
             "good": false,
             "characters": [
@@ -3093,6 +3382,7 @@
             "season": 13,
             "episode": 21,
             "description": "Homer and Marge become murder suspects after an elderly shut-in the couple befriended is found dead.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 301664323751,
             "good": true,
             "characters": [
@@ -3105,6 +3395,7 @@
             "season": 13,
             "episode": 22,
             "description": "When Wiggum and his men prove ineffective in controlling a citywide riot, townspeople begin to feel unsafe... until Homer forms his own police force.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 302880835773,
             "good": true,
             "characters": [
@@ -3116,6 +3407,7 @@
             "season": 14,
             "episode": 1,
             "description": "On Halloween, Homer's evil hammock produces an army of Homer clones; zombie cowboys threaten to destroy Springfield after Lisa outlaws guns; the Simpsons travel to an island inhabited by 'manimals.'",
+            "disneyplus_id": null,
             "simpsonsworld_id": 221301315863,
             "good": true,
             "characters": [
@@ -3127,6 +3419,7 @@
             "season": 14,
             "episode": 2,
             "description": "When a hidden camera tapes Homer lamenting that having a family meant kissing goodbye his dreams of becoming a rock 'n' roll star, Marge enrolls him a fantasy rock star camp run by The Rolling Stones.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 221293123693,
             "good": false,
             "characters": [
@@ -3138,6 +3431,7 @@
             "season": 14,
             "episode": 3,
             "description": "Bart and Lisa are horrified when they both end up in the same 3rd grade class.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 221347395722,
             "good": true,
             "characters": []
@@ -3147,6 +3441,7 @@
             "season": 14,
             "episode": 4,
             "description": "Marge's life changes dramatically when her attempt to lose weight via surgery resulting in larger breasts; Bart and Milhouse get into mischief that leads to a public relations nightmare for Krusty.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 221352515586,
             "good": false,
             "characters": [
@@ -3161,6 +3456,7 @@
             "season": 14,
             "episode": 5,
             "description": "When the Simpson house undergoes fumigation, the family is forced to seek shelter elsewhere... and ends up participating in a reality TV program set in a house from the 1800s.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 221388355650,
             "good": false,
             "characters": [
@@ -3172,6 +3468,7 @@
             "season": 14,
             "episode": 6,
             "description": "When someone attempts to murder Homer, Sideshow Bob is released from prison to help identify the culprit before he strikes again.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 221467203550,
             "good": false,
             "characters": [
@@ -3184,6 +3481,7 @@
             "season": 14,
             "episode": 7,
             "description": "When Bart gets Mrs. Krabappel nominated for Teacher of the Year, the family heads for Orlando to attend the ceremony.  But Skinner fears he may lose Krabappel forever... and asks Bart to sabotage the affair.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 221467715532,
             "good": true,
             "characters": [
@@ -3196,6 +3494,7 @@
             "season": 14,
             "episode": 8,
             "description": "Homer hires a shady private investigator to spy on Lisa when he realizes he doesn't know very much about his daughter.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 221531715548,
             "good": true,
             "characters": [
@@ -3208,6 +3507,7 @@
             "season": 14,
             "episode": 9,
             "description": "When Marge is mugged at the Kwik-E-Mart, she develops agoraphobia and ends up living in the basement... until she turns into a fearless bodybuilder.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 221532739689,
             "good": false,
             "characters": [
@@ -3219,6 +3519,7 @@
             "season": 14,
             "episode": 10,
             "description": "Inspired by Ned Flanders, Homer turns to prayer in hopes of changing his lot in life.  But when he injures himself coming out of church, Homer sues for damages... and is awarded the church itself.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 221526595805,
             "good": false,
             "characters": [
@@ -3230,6 +3531,7 @@
             "season": 14,
             "episode": 11,
             "description": "When Bart discovers the existence of an embarrassing TV commercial he appeared in as a baby-and that Homer spent the money he earned-he sues for emancipation and moves out of the house.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 221696067841,
             "good": false,
             "characters": [
@@ -3242,6 +3544,7 @@
             "season": 14,
             "episode": 12,
             "description": "When Lisa becomes a finalist in a spelling bee, she's offered a college scholarship in exchange for losing; Homer falls hopelessly in love with Krustyburger's limited-time-only rib sandwich.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 221698627830,
             "good": false,
             "characters": [
@@ -3254,6 +3557,7 @@
             "season": 14,
             "episode": 13,
             "description": "A Hollywood movie star takes a romantic interest in Ned Flanders, and when the relationship blossoms, Ned's faith is put to the test when the star wants to have premarital sex.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 221695043703,
             "good": false,
             "characters": [
@@ -3265,6 +3569,7 @@
             "season": 14,
             "episode": 14,
             "description": "When Springfield Airport changes the flight paths of airplanes, sending them over the Simpson's house, the family convinces Krusty to run for congress so he can change the law.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 221699651686,
             "good": true,
             "characters": [
@@ -3277,6 +3582,7 @@
             "season": 14,
             "episode": 15,
             "description": "On Valentine's Day, Homer attends a college course on how to succeed in the corporate world, he becomes the owner of the power plant and fires Mr. Burns... only to realize that running the plant means being away from family.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 221696067982,
             "good": true,
             "characters": [
@@ -3289,6 +3595,7 @@
             "season": 14,
             "episode": 16,
             "description": "As a British filmmaker makes a documentary about Springfield Elementary, Lisa tires to save the nighttime sky from light pollution, while Bart attempts to restore his coolness by obtaining a hood ornament from Fat Tony's car.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 221700675635,
             "good": false,
             "characters": [
@@ -3301,6 +3608,7 @@
             "season": 14,
             "episode": 17,
             "description": "Homer moves in with a gay couple after discovering a letter Marge wrote years earlier that implies she resents him.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 221699139984,
             "good": false,
             "characters": [
@@ -3313,6 +3621,7 @@
             "season": 14,
             "episode": 18,
             "description": "While vacationing at a dude ranch, Lisa falls for a cute 13-year-old cowboy; Homer vows to stop beavers who've dammed a river and kept Native Americans from their land.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 221700163549,
             "good": false,
             "characters": [
@@ -3325,6 +3634,7 @@
             "season": 14,
             "episode": 19,
             "description": "When Santa's Little Helper becomes Duff Beer's new, highly-paid mascot, his original owner comes out of the woodwork and claims the dog belongs to him.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 221701187546,
             "good": false,
             "characters": [
@@ -3336,6 +3646,7 @@
             "season": 14,
             "episode": 20,
             "description": "When Homer loses his driver's license, he embraces walking.  But Marge begins to suffer from stress when the pressure of being the only full-time driver in the house takes its toll-and ends up running Homer over in her car.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 229724227970,
             "good": false,
             "characters": [
@@ -3348,6 +3659,7 @@
             "season": 14,
             "episode": 21,
             "description": "After police discover Bart and Milhouse ransacking Flanders' Beatles memorabilia, Marge decides to place her son in a supervised activity, the Pre-Teen Braves.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 229731395601,
             "good": false,
             "characters": [
@@ -3359,6 +3671,7 @@
             "season": 14,
             "episode": 22,
             "description": "When Moe saves baby Maggie's life, a close bond forms.  But when Maggie wanders off with some gangsters, Homer and Marge mistakenly believe that Moe is responsible for the baby's disappearance.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 228412483812,
             "good": true,
             "characters": [
@@ -3373,6 +3686,7 @@
             "season": 15,
             "episode": 1,
             "description": "On Halloween, Homer takes over for the Grim Reaper and discovers Marge's name on his list; Professor Frink reanimates his father's corpse; Bart and Milhouse play pranks with a watch that can stop time.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 227335747784,
             "good": true,
             "characters": [
@@ -3384,6 +3698,7 @@
             "season": 15,
             "episode": 2,
             "description": "Mother Simpson is captured by police and placed on trial for sabotaging Mr. Burns' germ warfare plant in the 1960s.  Homer's heartfelt testimony helps win her release... but Mr. Burns concocts a plot to get revenge.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 227339843917,
             "good": true,
             "characters": [
@@ -3397,6 +3712,7 @@
             "season": 15,
             "episode": 3,
             "description": "When Lisa is elected student body president, she vows to make the school a better place to learn.  But Skinner tricks her into cutting well-liked programs... prompting Lisa to call a general student strike.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 227348035643,
             "good": false,
             "characters": [
@@ -3409,6 +3725,7 @@
             "season": 15,
             "episode": 4,
             "description": "The Simpsons travel to England, where Homer is imprisoned in the Tower of London after he smashes a car into the Queen's royal coach.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 227349059824,
             "good": false,
             "characters": [
@@ -3420,6 +3737,7 @@
             "season": 15,
             "episode": 5,
             "description": "Homer becomes the laughing stock of the town when a wild bear humiliates him.  But when he seeks a rematch, Homer bonds with the animal and tries to save its life.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 227355715580,
             "good": false,
             "characters": [
@@ -3431,6 +3749,7 @@
             "season": 15,
             "episode": 6,
             "description": "When Krusty takes the Sabbath off so he can study for his bar mitzvah, he chooses Homer as temporary guest host.  But when Homer's career unexpectedly takes off, Krusty finds himself out of a job.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 227360323557,
             "good": false,
             "characters": [
@@ -3443,6 +3762,7 @@
             "season": 15,
             "episode": 7,
             "description": "As Christmas approaches, Homer discovers the true meaning of the season after watching an animated version of A Christmas Carol on television.  But Flanders find it impossible to live as the second-nicest-guy in town.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 227364931670,
             "good": false,
             "characters": [
@@ -3455,6 +3775,7 @@
             "season": 15,
             "episode": 8,
             "description": "Marge opposes a political group made up of childless people who've grown fed-up with accommodating people with families.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 227369027832,
             "good": false,
             "characters": [
@@ -3466,6 +3787,7 @@
             "season": 15,
             "episode": 9,
             "description": "Homer builds a fighting robot for Bart, but finds he must hide inside the device to make it work; Lisa searches for a replacement for Snowball II when the cat is run over by a car.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 227376707538,
             "good": false,
             "characters": [
@@ -3479,6 +3801,7 @@
             "season": 15,
             "episode": 10,
             "description": "Homer buys an ambulance and starts responding to medical emergencies; Marge authors her own romance novel.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 227378755925,
             "good": true,
             "characters": [
@@ -3491,6 +3814,7 @@
             "season": 15,
             "episode": 11,
             "description": "Marge tells the children three historical tales: the story of King Henry the Eighth and his quest for a son; Sacagawea's journey with Lewis and Clark; and the rivalry between Mozart and Salieri.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 227386947567,
             "good": false,
             "characters": [
@@ -3502,6 +3826,7 @@
             "season": 15,
             "episode": 12,
             "description": "When Milhouse and his mother relocate to Capital City, Bart strikes up a friendship with Lisa; Homer makes money by pretending to be a transient.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 227392067706,
             "good": true,
             "characters": []
@@ -3511,6 +3836,7 @@
             "season": 15,
             "episode": 13,
             "description": "Lisa searches for a new identity when baby Maggie turns out to be smarter than her.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 229331523584,
             "good": true,
             "characters": [
@@ -3522,6 +3848,7 @@
             "season": 15,
             "episode": 14,
             "description": "Homer becomes the majority shareholder of Artie Ziff's troubled Internet company-and ends up being arrested by the Securities and Exchange Commission.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 227426371786,
             "good": true,
             "characters": [
@@ -3534,6 +3861,7 @@
             "season": 15,
             "episode": 15,
             "description": "When a drunken Homer loses control of his car, he places an unconscious Marge in the driver's seat so she'll be blamed for the accident; Lisa and Bart complain to the creator of the Cosmic Wars saga about his latest films.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 227399235673,
             "good": false,
             "characters": [
@@ -3546,6 +3874,7 @@
             "season": 15,
             "episode": 16,
             "description": "Bart's latest prank lands him in juvenile prison, where a tough girl forces him to go on the lam.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 227402307606,
             "good": true,
             "characters": [
@@ -3557,6 +3886,7 @@
             "season": 15,
             "episode": 17,
             "description": "Mrs. Krabappel dumps Principal Skinner at the altar and has a passionate affair with the Comic Book Guy.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 227423299561,
             "good": false,
             "characters": [
@@ -3570,6 +3900,7 @@
             "season": 15,
             "episode": 18,
             "description": "Bart and Lisa pursue Homer and Marge after they sneak away on a second honeymoon; Grampa catches the eye of a dashing Cuban man.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 227415619717,
             "good": false,
             "characters": [
@@ -3581,6 +3912,7 @@
             "season": 15,
             "episode": 19,
             "description": "Homer confronts evildoers in the form of his crime-fighting alter ego, the Pie Man-until Mr. Burns blackmails him into throwing a pie at the Dalai Lama.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 227327555884,
             "good": false,
             "characters": [
@@ -3593,6 +3925,7 @@
             "season": 15,
             "episode": 20,
             "description": "Homer reveals that Marge wasn't the first girl he ever kissed, but as he and Marge recount their versions of time spent at a summer camp, Homer realizes he caused Marge thirty years of heartbreak.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 227330115859,
             "good": false,
             "characters": [
@@ -3605,6 +3938,7 @@
             "season": 15,
             "episode": 21,
             "description": "The Simpsons are thrown in prison after Bart accidentally moons the American flag.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 227410499679,
             "good": false,
             "characters": [
@@ -3616,6 +3950,7 @@
             "season": 15,
             "episode": 22,
             "description": "Mr. Burns buys up all the media outlets in Springfield in an effort to polish his image, but soon finds himself at odds with Lisa, who started publishing her own newspaper.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 227405379707,
             "good": true,
             "characters": [
@@ -3628,6 +3963,7 @@
             "season": 16,
             "episode": 1,
             "description": "On Halloween... Flanders can predict when people will die; in Victorian London, Lisa and Bart hunt for a killer; the Simpsons take a fantastic voyage after Mr. Burns swallows a miniaturized Maggie.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 256741955834,
             "good": true,
             "characters": [
@@ -3639,6 +3975,7 @@
             "season": 16,
             "episode": 2,
             "description": "Marge enters a bakeoff competition, but ends up sabotaging the other entries; Bart decides to live the life of a swinger after discovering Playdude magazine.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 257840195722,
             "good": false,
             "characters": [
@@ -3651,6 +3988,7 @@
             "season": 16,
             "episode": 3,
             "description": "Lisa becomes self-conscious about her weight after kids at school make fun of her posterior;  Marge takes bully Nelson Muntz under her wing ... much to Bart's horror.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 256764995911,
             "good": false,
             "characters": [
@@ -3665,6 +4003,7 @@
             "season": 16,
             "episode": 4,
             "description": "Marge wonders if she made the right choices in life after she encounters a successful high school classmate who has traveled the world as a television news reporter.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 256753731544,
             "good": false,
             "characters": []
@@ -3674,6 +4013,7 @@
             "season": 16,
             "episode": 5,
             "description": "Homer builds a nuclear reactor for Lisa's science project; Bart makes money creating his own line of t-shirts.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 256759363799,
             "good": false,
             "characters": [
@@ -3687,6 +4027,7 @@
             "season": 16,
             "episode": 6,
             "description": "Homer and Grampa smuggle drugs out of Canada after Mr. Burns terminates his company's employee prescription drug program.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 1094235715818,
             "good": false,
             "characters": []
@@ -3696,6 +4037,7 @@
             "season": 16,
             "episode": 7,
             "description": "Homer mortgages his house to save Moe's bar, but Marge ends up taking control of the business and spends so much time with Moe that Homer fears his marriage is in trouble.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 256807491582,
             "good": false,
             "characters": []
@@ -3705,6 +4047,7 @@
             "season": 16,
             "episode": 8,
             "description": "After teaching famous athletes some victory dance moves, Homer is chosen to produce the Super Bowl half-time show; Flanders makes a movie featuring violent reenactments of biblical events.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 256813635887,
             "good": false,
             "characters": []
@@ -3714,6 +4057,7 @@
             "season": 16,
             "episode": 9,
             "description": "After sneaking off to a rap concert, Bart fakes his own kidnapping and inadvertently implicates Milhouse's father in the 'crime.'",
+            "disneyplus_id": null,
             "simpsonsworld_id": 256798275935,
             "good": false,
             "characters": []
@@ -3723,6 +4067,7 @@
             "season": 16,
             "episode": 10,
             "description": "When tourists shun Springfield, the town legalizes gay marriage in hopes of reversing the dire economic slowdown - and Homer makes money by becoming an ordained minister.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 256822339660,
             "good": false,
             "characters": []
@@ -3732,6 +4077,7 @@
             "season": 16,
             "episode": 11,
             "description": "After Bart torments his sister during a school field trip, Lisa gets a restraining order; Homer takes a job as a greeter at a local mega-store.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 256825923849,
             "good": false,
             "characters": []
@@ -3741,6 +4087,7 @@
             "season": 16,
             "episode": 12,
             "description": "Homer pretends to be Selma's husband when Selma travels to China to adopt a baby.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 264432707575,
             "good": false,
             "characters": []
@@ -3750,6 +4097,7 @@
             "season": 16,
             "episode": 13,
             "description": "Bart and Lisa attempt to save Homer and Marge's marriage after Homer spends the family's savings on a recreational vehicle.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 264432707841,
             "good": false,
             "characters": []
@@ -3759,6 +4107,7 @@
             "season": 16,
             "episode": 14,
             "description": "Homer becomes a prison snitch after he's convicted of breaking an outdated law; Lisa and Bart discover that Snowball II has a secret life.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 260844611804,
             "good": false,
             "characters": []
@@ -3768,6 +4117,7 @@
             "season": 16,
             "episode": 15,
             "description": "Using Professor Frink's astrological projection machine, Bart and Lisa peer into the future, where Bart breaks Lisa's heart by taking away her scholarship to Yale.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 260841027999,
             "good": false,
             "characters": []
@@ -3777,6 +4127,7 @@
             "season": 16,
             "episode": 16,
             "description": "Homer ends up in a mental institution after Marge grows convinced the contractor he befriended is a figment of his imagination; Marge allows Santa's Little Helper to stay at Grampa's retirement home.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 260835395771,
             "good": false,
             "characters": []
@@ -3786,6 +4137,7 @@
             "season": 16,
             "episode": 17,
             "description": "Bart has a heart attack after he becomes addicted to junk food; the Simpsons turn the house into a youth hostel, which is soon overrun by German backpackers.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 264207427808,
             "good": false,
             "characters": []
@@ -3795,6 +4147,7 @@
             "season": 16,
             "episode": 18,
             "description": "Homer behaves like a domineering stage mom after Lisa achieves fame by appearing in a singing competition on The Krusty the Clown Show.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 264212035982,
             "good": false,
             "characters": []
@@ -3804,6 +4157,7 @@
             "season": 16,
             "episode": 19,
             "description": "Homer is declared a prophet after he convinces everyone in town that the end of the world is at hand.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 264217155650,
             "good": false,
             "characters": [
@@ -3815,6 +4169,7 @@
             "season": 16,
             "episode": 20,
             "description": "Flanders feels like a fool after sorority girls run an adult Web site from his house without his knowledge, so he and the boys move away from Springfield... to a town where everyone looks like a Hummel figurine.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 264560707993,
             "good": false,
             "characters": []
@@ -3824,6 +4179,7 @@
             "season": 16,
             "episode": 21,
             "description": "After Bart gets expelled, he's enrolled in Catholic school, where he befriends a priest who wants to convert him and Homer to Catholicism.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 264455235845,
             "good": false,
             "characters": []
@@ -3833,6 +4189,7 @@
             "season": 17,
             "episode": 1,
             "description": "When Homer allows the mob to film a pornographic movie at the house, a disgusted Marge leaves the family and hooks up with a doctor trying to save the lives of manatees.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 273502275982,
             "good": false,
             "characters": [
@@ -3845,6 +4202,7 @@
             "season": 17,
             "episode": 2,
             "description": "Lisa must confront her darkest fears after a cemetery is relocated to the Simpsons' neighborhood.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 277101123962,
             "good": false,
             "characters": [
@@ -3856,6 +4214,7 @@
             "season": 17,
             "episode": 3,
             "description": "After Kirk and Luann rekindle their relationship, Bart and Milhouse plot to end the romance... only to inadvertently cause Homer and Marge to break up instead.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 273506371834,
             "good": false,
             "characters": [
@@ -3868,6 +4227,7 @@
             "season": 17,
             "episode": 4,
             "description": "On Halloween, Bart is replaced by a robotic boy after he falls into a coma; Burns hunts down Homer in a most dangerous game; a witch transforms trick-or-treaters into the costumes they're wearing.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 310466627927,
             "good": false,
             "characters": [
@@ -3879,6 +4239,7 @@
             "season": 17,
             "episode": 5,
             "description": "After spending time with her son, Marge begins to worry that she's turning Bart into a momma's boy; Homer enters an arm-wrestling competition.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 279766083701,
             "good": false,
             "characters": [
@@ -3891,6 +4252,7 @@
             "season": 17,
             "episode": 6,
             "description": "After winning popularity as the Safety Salamander, Homer challenges Quimby during a special mayoral recall election.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 273512003506,
             "good": false,
             "characters": []
@@ -3900,6 +4262,7 @@
             "season": 17,
             "episode": 7,
             "description": "A lonely Marge joins a women's group; Milhouse teaches Lisa how to speak Italian.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 279770179721,
             "good": false,
             "characters": []
@@ -3909,6 +4272,7 @@
             "season": 17,
             "episode": 8,
             "description": "The Simpsons travel to Italy to retrieve Mr. Burn's expensive new sports car... only to encounter Sideshow Bob and his murderous family.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 256858691577,
             "good": false,
             "characters": []
@@ -3918,6 +4282,7 @@
             "season": 17,
             "episode": 9,
             "description": "The Simpsons appear in three Christmas tales: the story of the birth of Jesus; a World War II tale featuring Grampa, Mr. Burns and Santa; and a musical featuring The Nutcracker suite.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 256885315702,
             "good": false,
             "characters": []
@@ -3927,6 +4292,7 @@
             "season": 17,
             "episode": 10,
             "description": "When an old letter is delivered to the Simpson home, Homer comes to believe that Grampa isn't his biological father after all.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 279775811924,
             "good": false,
             "characters": []
@@ -3936,6 +4302,7 @@
             "season": 17,
             "episode": 11,
             "description": "After Bart gets into trouble at school, Homer drives Bart to Oregon, where he attends a behavior modification camp; Marge becomes a popular drug dealer after she sells Homer's pain medications during a yard sale.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 310483523720,
             "good": false,
             "characters": []
@@ -3945,6 +4312,7 @@
             "season": 17,
             "episode": 12,
             "description": "Lisa vows to turn Groundskeeper Willie into a 'proper gentleman' in time for the upcoming school science fair; Homer tries to find something to wear after he rips his favorite blue pants.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 307171907536,
             "good": false,
             "characters": []
@@ -3954,6 +4322,7 @@
             "season": 17,
             "episode": 13,
             "description": "When the Simpsons become trapped inside a cave, Lisa recounts a story involving a bag of gold coins and how it affected the lives of Mr. Burns, Moe and Homer.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 277107267767,
             "good": false,
             "characters": []
@@ -3963,6 +4332,7 @@
             "season": 17,
             "episode": 14,
             "description": "Marge teaches Rod and Todd Flanders how to have fun; a lonely chimpanzee grabs hold of Bart.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 277113411511,
             "good": false,
             "characters": []
@@ -3972,6 +4342,7 @@
             "season": 17,
             "episode": 15,
             "description": "Marge swaps places with a British wife after the Simpsons become contestants on a reality television show.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 277119043544,
             "good": false,
             "characters": []
@@ -3981,6 +4352,7 @@
             "season": 17,
             "episode": 16,
             "description": "After costing Springfield a professional football team, Grampa tries to end his life, but the experience changes him, and he ends up becoming a matador.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 292950083730,
             "good": false,
             "characters": []
@@ -3990,6 +4362,7 @@
             "season": 17,
             "episode": 17,
             "description": "Mr. Burns closes the nuclear power plant and outsources all the jobs, forcing Homer to relocate to India; MacGyver fans Patty and Selma kidnap actor Richard Dean Anderson.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 283757123904,
             "good": false,
             "characters": []
@@ -3999,6 +4372,7 @@
             "season": 17,
             "episode": 18,
             "description": "The Simpsons appear in three stories set at sea: the journey of The Mayflower, the mutiny on The Bounty, and the capsizing of a cruise ship.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 310489667660,
             "good": false,
             "characters": []
@@ -4008,6 +4382,7 @@
             "season": 17,
             "episode": 19,
             "description": "After Skinner is fired for insinuating that girls are inferior to boys in math, Springfield Elementary is split into two groups-boys and girls-forcing Lisa to dress up like a boy so she can attend a math class.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 274367043639,
             "good": false,
             "characters": []
@@ -4017,6 +4392,7 @@
             "season": 17,
             "episode": 20,
             "description": "After Marge develops amnesia and can't remember anything about Homer, she decides to kick him out of the house and see other people.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 277125187506,
             "good": false,
             "characters": []
@@ -4026,6 +4402,7 @@
             "season": 17,
             "episode": 21,
             "description": "Lisa protests when Springfield passes a law requiring that creationism be taught alongside evolution in public schools.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 277127235959,
             "good": false,
             "characters": []
@@ -4035,6 +4412,7 @@
             "season": 17,
             "episode": 22,
             "description": "Homer and Marge play marriage counselors to help a baseball player and his sexy recording artist-wife.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 292955203576,
             "good": false,
             "characters": [
@@ -4047,6 +4425,7 @@
             "season": 18,
             "episode": 1,
             "description": "Lisa befriends the son of mobster Fat Tony, whose dream is to become a chef; Homer and Bart take over the 'family business' after Fat Tony is gunned down.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 292959299559,
             "good": false,
             "characters": [
@@ -4061,6 +4440,7 @@
             "season": 18,
             "episode": 2,
             "description": "Lisa grows jealous after Bart discovers he's a talented jazz drummer; Lisa hides some stray animals in the attic.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 283202115995,
             "good": false,
             "characters": [
@@ -4073,6 +4453,7 @@
             "season": 18,
             "episode": 3,
             "description": "Marge starts her own carpentry business, only to discover that men don't trust a woman to do the job; Bart discovers that Skinner is allergic to peanuts.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 283760707876,
             "good": false,
             "characters": [
@@ -4087,6 +4468,7 @@
             "season": 18,
             "episode": 4,
             "description": "The Simpsons appear in three tales of horror: Homer turns into a rampaging blob; a creature from Jewish folklore does Bart's bidding; a radio broadcast convinces townspeople they're being invaded by aliens.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 302871107984,
             "good": false,
             "characters": [
@@ -4098,6 +4480,7 @@
             "season": 18,
             "episode": 5,
             "description": "After Homer joins the Army, he's selected to play an enemy target during war games.  When the Army chases Homer into town, it pits the people of Springfield against the military.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 283080259896,
             "good": false,
             "characters": [
@@ -4109,6 +4492,7 @@
             "season": 18,
             "episode": 6,
             "description": "Lisa helps Moe get a poem published, but is deeply hurt when Moe refuses to acknowledge her contribution.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 307167299594,
             "good": false,
             "characters": [
@@ -4121,6 +4505,7 @@
             "season": 18,
             "episode": 7,
             "description": "Homer finds happiness after he buys an ice cream truck; Marge finds her purpose in life when she makes sculptures out of popsicle sticks.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 292941379558,
             "good": false,
             "characters": []
@@ -4130,6 +4515,7 @@
             "season": 18,
             "episode": 8,
             "description": "Bart becomes Nelson's best friend; Homer becomes hooked on one of Lisa's fantasy books.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 279785027791,
             "good": false,
             "characters": []
@@ -4139,6 +4525,7 @@
             "season": 18,
             "episode": 9,
             "description": "During the Christmas holiday, Marge attempts to muster the wherewithal to kick down-on-his-luck Gil out of the house.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 279793731867,
             "good": false,
             "characters": []
@@ -4148,6 +4535,7 @@
             "season": 18,
             "episode": 10,
             "description": "Marge returns to an island where she joyfully spent some of her childhood summers; Homer is forced to work on a fishing vessel that's threatened by a huge storm.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 283764803572,
             "good": false,
             "characters": []
@@ -4157,6 +4545,7 @@
             "season": 18,
             "episode": 11,
             "description": "The Simpsons spin three tales of revenge; Homer appears as the Count of Monte Cristo; Milhouse uses a gadget to get even with kids who've picked on him; comic hero Bart-Man searches for the villain who killed his parents.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 283790915851,
             "good": true,
             "characters": []
@@ -4166,6 +4555,7 @@
             "season": 18,
             "episode": 12,
             "description": "As Multicultural Day approaches, Lisa invents her own Native American heritage; after saving Springfield from a fire, Bart is rewarded with a driver's license-and ends up with a pregnant girlfriend who wants to wed.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 310462531619,
             "good": false,
             "characters": []
@@ -4175,6 +4565,7 @@
             "season": 18,
             "episode": 13,
             "description": "In this spoof of the 'Up' documentaries, a filmmaker chronicles the lives of a group of Springfield residents, including Homer, who has seemingly made good on his quest to become a millionaire.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 302876739533,
             "good": false,
             "characters": []
@@ -4184,6 +4575,7 @@
             "season": 18,
             "episode": 14,
             "description": "Lisa tutors Cletus's children - until Krusty hires them as a novelty act for his television show; Bart sees a female therapist after he's caught frightening his classmates with a scary story.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 307175491532,
             "good": false,
             "characters": []
@@ -4193,6 +4585,7 @@
             "season": 18,
             "episode": 15,
             "description": "Homer is horrified when his father begins dating Selma; Bart and Lisa build a fort after acquiring a large quantity of empty cardboard boxes.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 302868035943,
             "good": false,
             "characters": [
@@ -4208,6 +4601,7 @@
             "season": 18,
             "episode": 16,
             "description": "Homer tries his hand at making money by photographing celebrities and selling the images to the tabloids.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 292962371807,
             "good": false,
             "characters": [
@@ -4220,6 +4614,7 @@
             "season": 18,
             "episode": 17,
             "description": "After discovering the Internet, Marge becomes a character in a popular online fantasy game; Homer referees Lisa's soccer team.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 277036099916,
             "good": false,
             "characters": []
@@ -4229,6 +4624,7 @@
             "season": 18,
             "episode": 18,
             "description": "Bart becomes the shame of Springfield after a bungle on the playing field causes the Isotots to lose a pennant game; Homer and Marge fight Reverend Lovejoy and his wife over possession of Homer's mattress.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 279798851587,
             "good": false,
             "characters": []
@@ -4238,6 +4634,7 @@
             "season": 18,
             "episode": 19,
             "description": "Homer and his friends join the volunteer fire department, only to begin stealing from fire victims.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 310491203943,
             "good": false,
             "characters": []
@@ -4247,6 +4644,7 @@
             "season": 18,
             "episode": 20,
             "description": "When Santa's Little Helper gets a job on the police force, Bart buys a python to replace him.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 302865987860,
             "good": false,
             "characters": []
@@ -4256,6 +4654,7 @@
             "season": 18,
             "episode": 21,
             "description": "In this spoof of the television series '24,' Bart attempts to stop Jimbo, Dolph and Kearney before they unleash a deadly stink bomb at an upcoming school bake sale.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 292963907577,
             "good": false,
             "characters": []
@@ -4265,6 +4664,7 @@
             "season": 18,
             "episode": 22,
             "description": "Kent Brockman accidentally utters an obscenity during a news broadcast, leading to a heavy fine from the FCC - and costing Brockman his job.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 302859843984,
             "good": false,
             "characters": []
@@ -4274,6 +4674,7 @@
             "season": 19,
             "episode": 1,
             "description": "Marge hires a life coach to turn Homer around after he becomes convinced he's nothing but a loser.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 292943427892,
             "good": false,
             "characters": [
@@ -4285,6 +4686,7 @@
             "season": 19,
             "episode": 2,
             "description": "Homer becomes an opera star, only to find himself the target of an obsessed fan.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 350651459856,
             "good": false,
             "characters": [
@@ -4296,6 +4698,7 @@
             "season": 19,
             "episode": 3,
             "description": "Homer makes enemies when he starts his own tow truck business; Marge hires outside help to make Maggie more independent.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 292968003585,
             "good": false,
             "characters": [
@@ -4309,6 +4712,7 @@
             "season": 19,
             "episode": 4,
             "description": "Marge fears for her safety after breaking a promise to a bank robber about visiting him in jail.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 310455875747,
             "good": false,
             "characters": [
@@ -4320,6 +4724,7 @@
             "season": 19,
             "episode": 5,
             "description": "In three tales of Halloween terror: Homer and Marge attempt to eliminate one another after discovering their secret identities; Bart and Lisa aid Kodos the space alien; Flanders uses the seven deadly sins to punish Bart.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 302852163741,
             "good": false,
             "characters": [
@@ -4331,6 +4736,7 @@
             "season": 19,
             "episode": 6,
             "description": "When his parents are lost at sea and presumed dead, Milhouse becomes cooler than Bart; Homer finds himself in hot water when he can't remember the color of Marge's eyes.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 302855747799,
             "good": false,
             "characters": []
@@ -4340,6 +4746,7 @@
             "season": 19,
             "episode": 7,
             "description": "After Marge launches a gym for 'regular women' and becomes a successful businessperson, Homer decides to have his stomach stapled so she'll find him more attractive.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 294772803561,
             "good": false,
             "characters": []
@@ -4349,6 +4756,7 @@
             "season": 19,
             "episode": 8,
             "description": "After another of his attempts to kill the Simpsons is foiled, Sideshow Bob is put on trial.  During the proceedings, Bart accidentally kills his old nemesis.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 310458947589,
             "good": false,
             "characters": []
@@ -4358,6 +4766,7 @@
             "season": 19,
             "episode": 9,
             "description": "Homer wakes up from a blackout only to discover that Marge and the kids have left him.  Using a variety of methods, he probes his memory to unravel the mystery.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 302847555877,
             "good": false,
             "characters": []
@@ -4367,6 +4776,7 @@
             "season": 19,
             "episode": 10,
             "description": "When Springfield becomes the first city in the nation to hold a presidential primary, voters to turn the one person they can trust: Ralph Wiggum.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 307179075535,
             "good": false,
             "characters": []
@@ -4376,6 +4786,7 @@
             "season": 19,
             "episode": 11,
             "description": "Marge and Homer recount how Marge almost fell in love with a college professor during the 1990s.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 299664963588,
             "good": false,
             "characters": []
@@ -4385,6 +4796,7 @@
             "season": 19,
             "episode": 12,
             "description": "When Homer and Marge become trapped in a tunnel of love, three Valentine's Day stories unfold: Bonnie and Clyde steal each other's hearts; a take-off on 'Lady and the Tramp'; punk rockers Lisa and Nelson are hooked on sweets.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 310471235766,
             "good": false,
             "characters": []
@@ -4394,6 +4806,7 @@
             "season": 19,
             "episode": 13,
             "description": "Bart befriends a new kid at school, unaware that he's a snitch; after his car is damaged in an accident, Homer ends up with a fancy loaner.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 302849603730,
             "good": false,
             "characters": []
@@ -4403,6 +4816,7 @@
             "season": 19,
             "episode": 14,
             "description": "Bart and Lisa think they killed Martin Prince; Marge enlists the help of a reality TV show after Homer cheats on his diet.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 302849091724,
             "good": false,
             "characters": []
@@ -4412,6 +4826,7 @@
             "season": 19,
             "episode": 15,
             "description": "Lisa becomes addicted to secondhand smoke when she joins a ballet academy; Homer befriends raccoons who stole his beef jerky.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 310477379554,
             "good": false,
             "characters": []
@@ -4421,6 +4836,7 @@
             "season": 19,
             "episode": 16,
             "description": "Marge and Homer aid country singer Lurleen Lumpkin by reuniting her with her deadbeat father.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 283768387739,
             "good": false,
             "characters": []
@@ -4430,6 +4846,7 @@
             "season": 19,
             "episode": 17,
             "description": "Bart is overjoyed when the calf he's raising is judged Best in Show - until he realizes the animal is going to be slaughtered.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 302847555768,
             "good": false,
             "characters": []
@@ -4439,6 +4856,7 @@
             "season": 19,
             "episode": 18,
             "description": "Lisa's documentary about life with the Simpsons is accepted into Sundance, but Lisa's initial elation turns to horror when festival-goers begin humiliating her dysfunctional family.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 283769923976,
             "good": false,
             "characters": []
@@ -4448,6 +4866,7 @@
             "season": 19,
             "episode": 19,
             "description": "When Homer's mother returns to Springfield, she asks Homer for his forgiveness.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 299670083511,
             "good": false,
             "characters": []
@@ -4457,6 +4876,7 @@
             "season": 19,
             "episode": 20,
             "description": "Krusty hires Lisa to be his intern, but she's so good at the job, she ends up replacing him as host of his show; Bart and Homer discover the world of coin collecting.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 294774851723,
             "good": false,
             "characters": []
@@ -4466,6 +4886,7 @@
             "season": 20,
             "episode": 1,
             "description": "Homer and Flanders team-up as bounty hunters; Marge makes confections for an erotic bakery.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 311088195682,
             "good": true,
             "characters": [
@@ -4479,6 +4900,7 @@
             "season": 20,
             "episode": 2,
             "description": "When Bart steals actor Denis Leary's cell phone, Marge uses its built-in GPS signal to track her son... leading the family to the ancient ruins of Machu Picchu.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 304458307742,
             "good": false,
             "characters": [
@@ -4491,6 +4913,7 @@
             "season": 20,
             "episode": 3,
             "description": "Bart swaps places with his exact double-unaware that the double's wealthy siblings are plotting murder.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 304460355919,
             "good": false,
             "characters": []
@@ -4500,6 +4923,7 @@
             "season": 20,
             "episode": 4,
             "description": "On Halloween... Transformer-like robots duke it out in Springfield; Homer kills off celebrities so their likenesses can be exploited; the Simpsons appear in a spoof of a 'Peanuts' Halloween special.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 691895363987,
             "good": false,
             "characters": [
@@ -4511,6 +4935,7 @@
             "season": 20,
             "episode": 5,
             "description": "In a series of flashbacks... Homer and Marge end up in a cabin in the woods with newlyweds Flanders and Maude; Homer and Marge's marriage is nearly ruined when they meet exciting new people during a party.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 311675459549,
             "good": false,
             "characters": []
@@ -4520,6 +4945,7 @@
             "season": 20,
             "episode": 6,
             "description": "When Lisa discovers a talent for solving crossword puzzles, she enters a crossword tournament-unaware that Homer bet against her.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 310541891517,
             "good": false,
             "characters": [
@@ -4532,6 +4958,7 @@
             "season": 20,
             "episode": 7,
             "description": "Homer thinks Bart's new Muslim friend belongs to a family of terrorists; Lisa acquires her first iPod-like device.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 310498883779,
             "good": false,
             "characters": []
@@ -4541,6 +4968,7 @@
             "season": 20,
             "episode": 8,
             "description": "As Lisa tries to find a habitat for endangered bees, Mr. Burns builds a state-of-the-art sports arena-which happens to look like a giant hive.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 310506051725,
             "good": true,
             "characters": [
@@ -4553,6 +4981,7 @@
             "season": 20,
             "episode": 9,
             "description": "Lisa's new best friend creates a fantasy world so real it threatens to drive them apart.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 292944963870,
             "good": false,
             "characters": []
@@ -4562,6 +4991,7 @@
             "season": 20,
             "episode": 10,
             "description": "When Homer discovers that he was almost elected class president in high school, an old Italian cook uses a magic pot of tomato sauce to show him an alternate version of his life.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 273728067781,
             "good": false,
             "characters": []
@@ -4571,6 +5001,7 @@
             "season": 20,
             "episode": 11,
             "description": "Lisa freezes during a federal school assessment test; Homer tries to prevent accidents from happening after he forgets to pay an insurance bill; Skinner accompanies Bart and other underachievers on a trip to Capital City.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 277134915702,
             "good": false,
             "characters": []
@@ -4580,6 +5011,7 @@
             "season": 20,
             "episode": 12,
             "description": "When Homer and Marge's adjustable mortgage rate skyrockets, they're forced to move out of the house... until Flanders purchases the property and becomes their landlord.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 273029699673,
             "good": false,
             "characters": []
@@ -4589,6 +5021,7 @@
             "season": 20,
             "episode": 13,
             "description": "In this 'National Treasure'-like story... when Maggie disappears at a convent, Lisa goes undercover as a nun to solve a mystery involving a rare jewel.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 273030211958,
             "good": false,
             "characters": []
@@ -4598,6 +5031,7 @@
             "season": 20,
             "episode": 14,
             "description": "The Simpsons travel to Ireland, where Homer and Grampa purchase an old pub that's fallen on hard times.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 307849283838,
             "good": false,
             "characters": []
@@ -4607,6 +5041,7 @@
             "season": 20,
             "episode": 15,
             "description": "When their marriage license turns out to be invalid, Homer asks Marge to marry him in style.  But when Homer mysteriously disappears just before the wedding, Bart and Lisa search for answers.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 273024579646,
             "good": false,
             "characters": []
@@ -4616,6 +5051,7 @@
             "season": 20,
             "episode": 16,
             "description": "Moe meets a beautiful woman in an Internet chat room who turns out to be three feet tall; Homer tries to spend more time with Maggie.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 273066051746,
             "good": false,
             "characters": []
@@ -4625,6 +5061,7 @@
             "season": 20,
             "episode": 17,
             "description": "Bart dumps Milhouse in favor of a cute girl who volunteers her time at the retirement home; Lisa is prescribed antidepressants after she reads predictions about what Springfield will look like in 50 years.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 273057347598,
             "good": false,
             "characters": []
@@ -4634,6 +5071,7 @@
             "season": 20,
             "episode": 18,
             "description": "As a result of Homer's \"helicopter parenting,\" Lisa employs a trendy technique for boosting her popularity, while Bart enters a balsa-wood model-building contest; Marge discovers a sauna in the basement.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 273070659848,
             "good": false,
             "characters": []
@@ -4643,6 +5081,7 @@
             "season": 20,
             "episode": 19,
             "description": "Homer and Marge rent an apartment in tony Waverly Hills so Bart and Lisa can attend a better elementary school.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 299732035764,
             "good": false,
             "characters": []
@@ -4652,6 +5091,7 @@
             "season": 20,
             "episode": 20,
             "description": "As Marge and Lisa have their nails done, they spin four tales involving famous women: Queen Elizabeth, Snow White, Lady Macbeth and Ayn Rand.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 273732163923,
             "good": false,
             "characters": []
@@ -4661,6 +5101,7 @@
             "season": 20,
             "episode": 21,
             "description": "Springfield grapples with an immigration problem when the economy of nearby Ogdenville collapses.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 729848899646,
             "good": false,
             "characters": []
@@ -4670,6 +5111,7 @@
             "season": 21,
             "episode": 1,
             "description": "Homer ends up with a superhero's physique after he's chosen to appear in a film based on a character created by The Comic Book Guy.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 250297923589,
             "good": false,
             "characters": [
@@ -4682,6 +5124,7 @@
             "season": 21,
             "episode": 2,
             "description": "Principal Skinner fires Mrs. Krabappel after she makes a drunken fool of herself at the elementary school - but what Skinner doesn't know is that Bart spiked her coffee with alcohol.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 310517315862,
             "good": false,
             "characters": [
@@ -4694,6 +5137,7 @@
             "season": 21,
             "episode": 3,
             "description": "Marge vows to drive mixed martial arts from Springfield by defeating a fight promoter in the ring.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 250299971833,
             "good": false,
             "characters": [
@@ -4705,6 +5149,7 @@
             "season": 21,
             "episode": 4,
             "description": "Classic movie monsters are attacked by their spouses; Lisa and Bart exchange murders in a Hitchcock spoof; Bart is the key to saving Springfield from zombies; Moe's microbrewery mixes beer with Homer's blood.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 262634051998,
             "good": false,
             "characters": [
@@ -4716,6 +5161,7 @@
             "season": 21,
             "episode": 5,
             "description": "Homer's life turns into nonstop misery when he becomes Carl's assistant; Marge poses for a sexy calendar.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 250304067959,
             "good": false,
             "characters": [
@@ -4729,6 +5175,7 @@
             "season": 21,
             "episode": 6,
             "description": "Skinner tells Bart about a former Springfield Elementary student who was the best prankster ever; Marge begins shopping at a natural foods store.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 792414787985,
             "good": false,
             "characters": []
@@ -4738,6 +5185,7 @@
             "season": 21,
             "episode": 7,
             "description": "Lisa befriends a group of Wiccans who are accused of blinding the people of Springfield with a spell.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 250307139830,
             "good": false,
             "characters": []
@@ -4747,6 +5195,7 @@
             "season": 21,
             "episode": 8,
             "description": "Bart attempts to get Homer and Marge pregnant so he can have a brother to hang out with.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 250311235599,
             "good": false,
             "characters": []
@@ -4756,6 +5205,7 @@
             "season": 21,
             "episode": 9,
             "description": "Homer becomes jealous when a reporter takes an interest in Grampa's life; Lisa loses a stuffed lamb that Bart brought home from school.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 250369603964,
             "good": false,
             "characters": []
@@ -4765,6 +5215,7 @@
             "season": 21,
             "episode": 10,
             "description": "Krusty ends up playing second fiddle to Princess Penelope, a new character on his show... only to end up falling in love with the actress who plays her.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 250379331672,
             "good": false,
             "characters": []
@@ -4774,6 +5225,7 @@
             "season": 21,
             "episode": 11,
             "description": "Homer wins a million-dollar lottery but doesn't tell his family the news; Lisa stimulates nursing home patients with an interactive Wii-like device.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 279804995696,
             "good": false,
             "characters": []
@@ -4783,6 +5235,7 @@
             "season": 21,
             "episode": 12,
             "description": "The Simpsons head to the Winter Olympics in Canada after Marge and Homer join a curling team; Lisa becomes addicted to collecting Olympic pins.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 250385475646,
             "good": false,
             "characters": []
@@ -4792,6 +5245,7 @@
             "season": 21,
             "episode": 13,
             "description": "Lisa discovers that her Southern ancestors helped a slave escape to freedom.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 255100483932,
             "good": false,
             "characters": []
@@ -4801,6 +5255,7 @@
             "season": 21,
             "episode": 14,
             "description": "Bart creates friction between Marge and Homer so he can get out of doing homework.  But when the plot fails, Bart tries to destroy the elementary school by reactivating an old Springfield subway line.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 250390595937,
             "good": false,
             "characters": []
@@ -4810,6 +5265,7 @@
             "season": 21,
             "episode": 15,
             "description": "Bart stirs up trouble when he kisses a girl at school; Lisa's popularity soars when she receives a failing grade on a test.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 250397251688,
             "good": false,
             "characters": []
@@ -4819,6 +5275,7 @@
             "season": 21,
             "episode": 16,
             "description": "Flanders attempts to redeem Homer during a Bible study trip to Israel; Homer becomes delusional after getting lost in the desert and ends up believing he's the Chosen One.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 279809091713,
             "good": false,
             "characters": []
@@ -4828,6 +5285,7 @@
             "season": 21,
             "episode": 17,
             "description": "When Mr. Burns is sent to prison for possessing stolen art, he places Smithers in charge of running the nuclear power plant; Bart helps Lisa maintain an ant farm.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 250508867924,
             "good": false,
             "characters": []
@@ -4837,6 +5295,7 @@
             "season": 21,
             "episode": 18,
             "description": "After he's sentenced to perform community service, Homer befriends Chief Wiggum; Marge mistakes Bart's love for a Japanese card game for a drug addiction.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 250515523850,
             "good": false,
             "characters": []
@@ -4846,6 +5305,7 @@
             "season": 21,
             "episode": 19,
             "description": "Lisa comes to the aid of a whale that washes up on Springfield Beach.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 250519619700,
             "good": false,
             "characters": []
@@ -4855,6 +5315,7 @@
             "season": 21,
             "episode": 20,
             "description": "After a bomb squad mistakenly blows up Homer's unattended gym bag, releasing radiation into the city, Springfield equips itself with surveillance cameras to deter terrorism, allowing Flanders to impose his views on others.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 250523203904,
             "good": false,
             "characters": []
@@ -4864,6 +5325,7 @@
             "season": 21,
             "episode": 21,
             "description": "As Mother's Day approaches, Homer, Apu and Reverend Lovejoy receive a letter from Moe warning that he's going to run away with one of their wives.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 250592323527,
             "good": false,
             "characters": []
@@ -4873,6 +5335,7 @@
             "season": 21,
             "episode": 22,
             "description": "Bart is convinced that his new neighbor is Sideshow Bob - even though the man looks nothing like his arch enemy.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 250531907855,
             "good": false,
             "characters": []
@@ -4882,6 +5345,7 @@
             "season": 21,
             "episode": 23,
             "description": "Moe discovers a talent for judging contests, leading to an appearance on the television series 'American Idol;' Homer drives Marge crazy when he begins hanging around the house.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 255074883631,
             "good": false,
             "characters": []
@@ -4891,6 +5355,7 @@
             "season": 22,
             "episode": 1,
             "description": "Lisa attends a performing arts camp; Krusty stands trial in The Hague after being tricked into believing he won the Nobel Prize.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 263519811935,
             "good": false,
             "characters": []
@@ -4900,6 +5365,7 @@
             "season": 22,
             "episode": 2,
             "description": "Lisa donates money to a microfinance bank to help Nelson's custom bicycle company; Homer games the system by purchasing expensive items from stores and, after using them for a period of time, returns them for a refund.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 263525955686,
             "good": false,
             "characters": []
@@ -4909,6 +5375,7 @@
             "season": 22,
             "episode": 3,
             "description": "Lisa becomes the coach of Bart's Little League team... and ends up firing Bart after he ignores her instructions.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 263531587720,
             "good": false,
             "characters": []
@@ -4918,6 +5385,7 @@
             "season": 22,
             "episode": 4,
             "description": "Bart and Milhouse use their videogame skills to save Springfield; in a 'Dead Calm' spoof a vacationing Homer and Marge rescue a stranger who may be a murderer; Lisa falls for a hunky vampire in a spoof of 'Twilight'.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 263577155794,
             "good": false,
             "characters": [
@@ -4929,6 +5397,7 @@
             "season": 22,
             "episode": 5,
             "description": "Lisa decides she doesn't want to end up like Marge; Bart becomes the new school bully after Nelson is humiliated by a series of mishaps; Maggie becomes obsessed with owning a collectible elf figure.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 263540291528,
             "good": false,
             "characters": []
@@ -4938,6 +5407,7 @@
             "season": 22,
             "episode": 6,
             "description": "When a dying Mr. Burns loses his memory, the residents of Springfield exact revenge on the abusive billionaire by using him as their plaything.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 263544387571,
             "good": false,
             "characters": []
@@ -4947,6 +5417,7 @@
             "season": 22,
             "episode": 7,
             "description": "The Simpsons decide to give away Santa's Little Helper after the dog swallows Bart's beloved carrier pigeon.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 263545923923,
             "good": false,
             "characters": []
@@ -4956,6 +5427,7 @@
             "season": 22,
             "episode": 8,
             "description": "Four Christmas tales... Bart takes a 'Polar Express' ride to ask Santa for a dirt bike; Lisa worries after Marge is drafted to fight Nazis; Martha Stewart helps spruce-up the house; the family celebrates a Muppet Christmas.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 263551043814,
             "good": false,
             "characters": []
@@ -4965,6 +5437,7 @@
             "season": 22,
             "episode": 9,
             "description": "Acting as an undercover informant, Homer sets out to win the trust of mobster Fat Tony as part of the FBI's efforts to break up his crime syndicate.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 263572035826,
             "good": false,
             "characters": []
@@ -4974,6 +5447,7 @@
             "season": 22,
             "episode": 10,
             "description": "As Bart tries to determine the origin of a scar on his hand, Marge reacquaints herself with three old friends.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 256848451515,
             "good": false,
             "characters": []
@@ -4983,6 +5457,7 @@
             "season": 22,
             "episode": 11,
             "description": "Smithers convinces Moe to turn his tavern into a gay bar; with Bart's help, Skinner romances the elementary school's new music teacher.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 263579715535,
             "good": false,
             "characters": []
@@ -4992,6 +5467,7 @@
             "season": 22,
             "episode": 12,
             "description": "Homer uses plotlines from a 1980's sitcom to deal with Bart when the boy grows obsessed with obtaining a cool mini-bike; Bart attempts to trade nuclear secrets to the Chinese government.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 256851523744,
             "good": false,
             "characters": []
@@ -5001,6 +5477,7 @@
             "season": 22,
             "episode": 13,
             "description": "Unable to get a date for Valentine's Day, Moe asks Homer to act as his 'wingman' and help him attract women; Marge has her entire head of hair dyed gray after she discovers her first gray hair.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 254809667917,
             "good": false,
             "characters": []
@@ -5010,6 +5487,7 @@
             "season": 22,
             "episode": 14,
             "description": "When the 'Angry Dad' character is turned into an award-winning animated short film, Homer hogs the spotlight... much to Bart's dismay.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 254814275630,
             "good": false,
             "characters": []
@@ -5019,6 +5497,7 @@
             "season": 22,
             "episode": 15,
             "description": "When Lisa discovers a wildflower that turns scorpions into blissful creatures, Homer secretly spikes Grampa's coffee with juice from the plant, turning him into a docile old man.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 254817859928,
             "good": false,
             "characters": []
@@ -5028,6 +5507,7 @@
             "season": 22,
             "episode": 16,
             "description": "When legendary comics Cheech and Chong split up, Cheech asks Homer to replace his old partner; Marge helps the Cat Lady empty her house of junk... only to become a hoarder herself.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 254821955889,
             "good": false,
             "characters": []
@@ -5037,6 +5517,7 @@
             "season": 22,
             "episode": 17,
             "description": "Homer enrolls in a fathering enrichment class, where he undergoes treatment to stop the urge to strangle Bart.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 254830659539,
             "good": false,
             "characters": []
@@ -5046,6 +5527,7 @@
             "season": 22,
             "episode": 18,
             "description": "Lisa befriends an old magician who shows her how to perform one of Houdini's greatest tricks.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 254866499808,
             "good": false,
             "characters": []
@@ -5055,6 +5537,7 @@
             "season": 22,
             "episode": 19,
             "description": "Fat Tony asks for Selma's hand in marriage; Bart discovers a talent for sniffing out truffles.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 254870083832,
             "good": false,
             "characters": []
@@ -5064,6 +5547,7 @@
             "season": 22,
             "episode": 20,
             "description": "Homer discovers a talent for cutting women's hair; Lisa becomes puzzled when a pretty girl at school shows an interest in Milhouse.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 254876227684,
             "good": false,
             "characters": []
@@ -5073,6 +5557,7 @@
             "season": 22,
             "episode": 21,
             "description": "A drawer full of old keys sparks several adventures: Homer steals the Duff blimp; Bart discovers he can do no wrong; Lisa discovers a strange room beneath Springfield Elementary; Marge and Maggie chase a toy train.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 254880835816,
             "good": false,
             "characters": []
@@ -5082,6 +5567,7 @@
             "season": 22,
             "episode": 22,
             "description": "Ned Flanders falls for Bart's teacher, Edna Krabappel... but will Krabappel's reputation for dating every guy in town spell the end of the relationship?",
+            "disneyplus_id": null,
             "simpsonsworld_id": 255101507699,
             "good": false,
             "characters": []
@@ -5091,6 +5577,7 @@
             "season": 23,
             "episode": 1,
             "description": "Homer attempts to help a former CIA agent plagued by violent flashbacks from his past.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 273517123847,
             "good": false,
             "characters": [
@@ -5102,6 +5589,7 @@
             "season": 23,
             "episode": 2,
             "description": "Superintendant Chalmers teaches Bart about Teddy Roosevelt after personally taking charge of the boy's education. When Chalmers loses his job, Bart and his classmates attempt to get him reinstated.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 273518659843,
             "good": true,
             "characters": [
@@ -5114,6 +5602,7 @@
             "season": 23,
             "episode": 3,
             "description": "In three terrifying Halloween tales... Homer discovers a unique way to communicate with his family; a spoof of 'Dexter' features Homer tricking Flanders; a spoof of the movie 'Avatar' features Bart as a tentacled alien.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 230493251807,
             "good": false,
             "characters": [
@@ -5125,6 +5614,7 @@
             "season": 23,
             "episode": 4,
             "description": "With some help from Martin Prince, Bart constructs cute, baby seal-like robots that rival Lisa's entry in a science fair project; Homer ends up working for his new assistant.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 273736771817,
             "good": false,
             "characters": [
@@ -5137,6 +5627,7 @@
             "season": 23,
             "episode": 5,
             "description": "As Homer and Marge vie for the kids' approval... Marge, Bart and Lisa become successful food bloggers; Homer finds himself trapped in a meth lab after Marge deliberately gives him the wrong address for a restaurant.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 233194563539,
             "good": false,
             "characters": [
@@ -5148,6 +5639,7 @@
             "season": 23,
             "episode": 6,
             "description": "After Lisa discovers that her favorite author doesn't exist, Homer forms a literary gang in hopes of writing a bestselling \"tween\" novel and raking in millions.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 264559171655,
             "good": false,
             "characters": [
@@ -5160,6 +5652,7 @@
             "season": 23,
             "episode": 7,
             "description": "Burns appoints Homer the nuclear power plant's new account man, damning him to a 'Mad Men'-like existence; Lisa becomes Bart's mentor.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 1071533123906,
             "good": false,
             "characters": [
@@ -5171,6 +5664,7 @@
             "season": 23,
             "episode": 8,
             "description": "After being fired from his popular kids' show, Krusty stages a comeback with help from an agent who's also an old flame.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 230516291714,
             "good": false,
             "characters": [
@@ -5182,6 +5676,7 @@
             "season": 23,
             "episode": 9,
             "description": "Thirty years in the future, Bart and Lisa attempt to bond with their children on Christmas; an unwed Maggie gives birth while heading home for the holidays.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 230516803889,
             "good": false,
             "characters": [
@@ -5194,6 +5689,7 @@
             "season": 23,
             "episode": 10,
             "description": "Homer becomes a celebrity after he voices his conservative opinions on a cable talk show, and attempts to convince leaders of the Republican party to nominate singer Ted Nugent for president.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 230549059731,
             "good": false,
             "characters": [
@@ -5205,6 +5701,7 @@
             "season": 23,
             "episode": 11,
             "description": "Lisa's idea for an online social network becomes a tremendous hit, but so many people become addicted to posting on the site, it leads to chaos.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 230552131592,
             "good": false,
             "characters": [
@@ -5216,6 +5713,7 @@
             "season": 23,
             "episode": 12,
             "description": "Moe's bar rag tells the story of his existence; Milhouse tires of taking abuse from Bart.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 230553667901,
             "good": false,
             "characters": []
@@ -5225,6 +5723,7 @@
             "season": 23,
             "episode": 13,
             "description": "As Valentine's Day approaches, Marge grows concerned when Lisa finds a boyfriend; Bart and Milhouse set out on a 'mythbusting' mission at Springfield Elementary.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 230562371905,
             "good": false,
             "characters": []
@@ -5234,6 +5733,7 @@
             "season": 23,
             "episode": 14,
             "description": "Fed up with the family's negative impact on the city, townspeople banish the Simpsons from Springfield.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 230541891832,
             "good": false,
             "characters": []
@@ -5243,6 +5743,7 @@
             "season": 23,
             "episode": 15,
             "description": "Bart becomes a famous street artist after he plasters Springfield with unflattering graffiti of Homer's likeness; Apu panics when he's forced to compete with a friendly grocery store chain featuring a South Pacific motif.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 304468035701,
             "good": false,
             "characters": []
@@ -5252,6 +5753,7 @@
             "season": 23,
             "episode": 16,
             "description": "With help from one of Professor Frink's inventions, Marge and the kids enter Homer's dreams in hopes of curing him of incontinence.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 230597187582,
             "good": false,
             "characters": []
@@ -5261,6 +5763,7 @@
             "season": 23,
             "episode": 17,
             "description": "Homer becomes the last human employee at the nuclear power plant after Mr. Burns orders a mass firing and replaces staffers with robots.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 230592067926,
             "good": false,
             "characters": []
@@ -5270,6 +5773,7 @@
             "season": 23,
             "episode": 18,
             "description": "Bart falls for Jimbo's girlfriend Shauna; Homer buys a tricked-out treadmill so he can watch old episodes of a 'Lost'-like television show.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 311189571768,
             "good": false,
             "characters": []
@@ -5279,6 +5783,7 @@
             "season": 23,
             "episode": 19,
             "description": "The Simpsons vacation on a cruise liner, where Bart has so much fun he concocts a scheme to keep his family aboard the ship forever.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 273522243657,
             "good": false,
             "characters": []
@@ -5288,6 +5793,7 @@
             "season": 23,
             "episode": 20,
             "description": "After being injured at work, Homer is given eight weeks of paid vacation, and decides to keep the news secret from his family; Bart gets Nelson hooked on Krustyburgers so he'll gain weight and stop picking on him.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 230588995967,
             "good": false,
             "characters": []
@@ -5297,6 +5803,7 @@
             "season": 23,
             "episode": 21,
             "description": "Complications ensue when Flanders and Krabappel admit they're secretly married.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 277098051530,
             "good": false,
             "characters": []
@@ -5306,6 +5813,7 @@
             "season": 23,
             "episode": 22,
             "description": "Singer Lady Gaga attempts to cheer Lisa after she's voted the most unpopular kid at school.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 233190467851,
             "good": false,
             "characters": []
@@ -5315,6 +5823,7 @@
             "season": 24,
             "episode": 1,
             "description": "Bart seeks out Cletus's daughter, who has started a new life in New York City, Lisa wants to take in a Broadway play but ends up performing Shakespeare in Central Park.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 221691971633,
             "good": false,
             "characters": []
@@ -5324,6 +5833,7 @@
             "season": 24,
             "episode": 2,
             "description": "In these three Halloween tales... a black hole threatens to destroy Springfield; the Simpsons are terrorized by the unknown in a spoof of 'Paranormal Activity'; Bart time travels in a spoof of 'Back to the Future.'",
+            "disneyplus_id": null,
             "simpsonsworld_id": 221695555645,
             "good": true,
             "characters": [
@@ -5335,6 +5845,7 @@
             "season": 24,
             "episode": 3,
             "description": "Marge decides she wants to conceive another child; Bart realizes Lisa is up to something mysterious and vows to find out what it is.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 221688899646,
             "good": false,
             "characters": []
@@ -5344,6 +5855,7 @@
             "season": 24,
             "episode": 4,
             "description": "Homer and Marge search for Grampa after he disappears from the retirement home; Homer invests Lisa's college fund in an online poker Web site.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 221688899887,
             "good": false,
             "characters": []
@@ -5353,6 +5865,7 @@
             "season": 24,
             "episode": 5,
             "description": "While serving jury duty, Fat Tony appoints an accountant as his temporary Don; an anemic Lisa eats bugs to increase her iron level.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 221694531617,
             "good": false,
             "characters": []
@@ -5362,6 +5875,7 @@
             "season": 24,
             "episode": 6,
             "description": "After his beloved new tablet \"MyPad\" computer is destroyed, a despondent Homer finds solace in a message seemingly written by God - until newsman Kent Brockman sets out to debunk the \"miracle.\"",
+            "disneyplus_id": null,
             "simpsonsworld_id": 229733443727,
             "good": false,
             "characters": []
@@ -5371,6 +5885,7 @@
             "season": 24,
             "episode": 7,
             "description": "Homer is elated when a cool dad and his family move next door, but his happiness ends when he realizes he has little in common with his new neighbors.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 222374467937,
             "good": false,
             "characters": []
@@ -5380,6 +5895,7 @@
             "season": 24,
             "episode": 8,
             "description": "When Bart accuses Homer of not liking Santa's Little Helper, Grampa recounts the story of how Homer's heart broke after he was forced to give away his childhood dog.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 222491715618,
             "good": false,
             "characters": []
@@ -5389,6 +5905,7 @@
             "season": 24,
             "episode": 9,
             "description": "The Simpsons anticipate the apocalypse after Homer inadvertently triggers a shockwave that disables all electronic devices in Springfield.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 1094312515873,
             "good": false,
             "characters": []
@@ -5398,6 +5915,7 @@
             "season": 24,
             "episode": 10,
             "description": "Bart must pass a district-wide test to save Springfield Elementary; Homer uses a discarded parking meter to steal from unsuspecting drivers.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 222388291945,
             "good": false,
             "characters": []
@@ -5407,6 +5925,7 @@
             "season": 24,
             "episode": 11,
             "description": "After narrowly surviving a tornado, Marge and Homer embark on a search for a couple who'll serve as Bart, Lisa and Maggie's legal guardians.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 257684035668,
             "good": false,
             "characters": []
@@ -5416,6 +5935,7 @@
             "season": 24,
             "episode": 12,
             "description": "Bart attempts to patch things up with his old sweetheart, Mary Spuckler, and despite Lisa's input, still manages to sabotage his chances of finding love.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 257681987573,
             "good": false,
             "characters": []
@@ -5425,6 +5945,7 @@
             "season": 24,
             "episode": 13,
             "description": "With Bart's help, Milhouse transforms into his father; Homer discovers a talent for finding things in hidden-picture books.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 257686595928,
             "good": false,
             "characters": []
@@ -5434,6 +5955,7 @@
             "season": 24,
             "episode": 14,
             "description": "With encouragement from Mr. Burns, Grampa revives a famous wrestling character from his past whom audiences love to hate, and despite Homer and Marge's objections, incorporates Bart into the act.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 257687107857,
             "good": false,
             "characters": []
@@ -5443,6 +5965,7 @@
             "season": 24,
             "episode": 15,
             "description": "When Flanders gives Homer a black eye, he turns to the Bible for answers; Lisa is shocked and puzzled when she discovers that a substitute teacher hates her.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 257689667578,
             "good": false,
             "characters": []
@@ -5452,6 +5975,7 @@
             "season": 24,
             "episode": 16,
             "description": "Bart stands trial in youth court after he's accused of pulling an Easter prank; after buying a comic book collection, Mr. Burns transforms into a 'Batman'-like superhero.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 257714243647,
             "good": false,
             "characters": []
@@ -5461,6 +5985,7 @@
             "season": 24,
             "episode": 17,
             "description": "In an episode that focuses on the choices people make and their outcomes... Homer attempts to save his marriage; Milhouse woos Lisa.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 1094243907551,
             "good": false,
             "characters": []
@@ -5470,6 +5995,7 @@
             "season": 24,
             "episode": 18,
             "description": "Lovejoy quits the church after the Parson appoints a charismatic reverend to reinvigorate the parish; Marge tracks down her old wedding dress.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 257728579751,
             "good": false,
             "characters": []
@@ -5479,6 +6005,7 @@
             "season": 24,
             "episode": 19,
             "description": "Moe's new suit catches the attention of venture capitalists, leading to the distribution of Moe's own brand of whiskey; Bart cares for Grampa; Lisa realizes that her favorite musicians have been turned into holograms.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 257737283653,
             "good": false,
             "characters": []
@@ -5488,6 +6015,7 @@
             "season": 24,
             "episode": 20,
             "description": "Bart takes piano lessons in hopes of impressing his beautiful young teacher; Homer goes completely bald; Marge teaches a Russian man how to drive.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 257760323921,
             "good": false,
             "characters": []
@@ -5497,6 +6025,7 @@
             "season": 24,
             "episode": 21,
             "description": "Homer, Moe and Lenny travel to Iceland to retrieve lottery winnings that Carl ran off with.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 257753667515,
             "good": false,
             "characters": []
@@ -5506,6 +6035,7 @@
             "season": 24,
             "episode": 22,
             "description": "Homer secretly reconstructs a kiddy train as Marge's anniversary present; Marge attracts the attention of a potential paramour online.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 257768003795,
             "good": false,
             "characters": []
@@ -5515,6 +6045,7 @@
             "season": 25,
             "episode": 1,
             "description": "When Homer returns from a Nuclear Workers Convention and begins behaving strangely, Lisa worries that her father has been brainwashed and is now part of a terrorist plot to blow up the power plant.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 307191875741,
             "good": false,
             "characters": []
@@ -5524,6 +6055,7 @@
             "season": 25,
             "episode": 2,
             "description": "In three terrifying Halloween tales, Bart, Lisa and Maggie receive a visit from The Fat in the Hat; when Bart is decapitated, his head is sewn onto Lisa's body; Homer plots to kill Moe at a circus freak show.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 310259779794,
             "good": false,
             "characters": [
@@ -5535,6 +6067,7 @@
             "season": 25,
             "episode": 3,
             "description": "A Springfield funeral prompts Marge, Kent Brockman, Homer and Mr. Burns to reexamine a crucial decision in their lives one that has brought them the most regret.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 311688259548,
             "good": false,
             "characters": []
@@ -5544,6 +6077,7 @@
             "season": 25,
             "episode": 4,
             "description": "After experiencing a midlife crisis, Homer reaches out to an old pen pal; when a cheating scandal rocks Springfield Elementary, Lisa establishes an honor code.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 304473155645,
             "good": false,
             "characters": []
@@ -5553,6 +6087,7 @@
             "season": 25,
             "episode": 5,
             "description": "Homer gets trapped in an elevator with a pregnant woman and helps deliver her baby; Lisa helps underpaid cheerleaders organize so they can demand a salary increase from a greedy football team owner.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 311105091548,
             "good": false,
             "characters": []
@@ -5562,6 +6097,7 @@
             "season": 25,
             "episode": 6,
             "description": "Lisa is elated to befriend Isabel, a smart new student at school, only to realize that she and Isabel are on opposite sides of the political spectrum.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 310523971648,
             "good": false,
             "characters": []
@@ -5571,6 +6107,7 @@
             "season": 25,
             "episode": 7,
             "description": "Bart seeks revenge after Skinner prevents him from attending a school field trip aboard a submarine; Lisa suggests to the financially-strapped Krusty that he sell the foreign rights to his television show.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 304476739664,
             "good": false,
             "characters": []
@@ -5580,6 +6117,7 @@
             "season": 25,
             "episode": 8,
             "description": "As Christmas approaches, Marge transforms the house into a bed and breakfast after Springfield becomes the only town in America to receive snowfall; Lisa vows to give her loved ones modest gifts that come from the heart.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 307199043880,
             "good": false,
             "characters": []
@@ -5589,6 +6127,7 @@
             "season": 25,
             "episode": 9,
             "description": "Homer is put on trial after the FBI catches him illegally downloading movies from the Internet.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 310523459925,
             "good": false,
             "characters": []
@@ -5598,6 +6137,7 @@
             "season": 25,
             "episode": 10,
             "description": "The Comic Book Guy marries a Japanese woman, only to discover that the woman's father disapproves of the union.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 310541379637,
             "good": false,
             "characters": []
@@ -5607,6 +6147,7 @@
             "season": 25,
             "episode": 11,
             "description": "Homer uses augmented reality glasses to spy on Marge; Nelson demands a Valentine's Day card from Bart.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 307204163997,
             "good": false,
             "characters": []
@@ -5616,6 +6157,7 @@
             "season": 25,
             "episode": 12,
             "description": "Bart befriends a fellow student and falconry expert, only to discover that the boy suffers from mental illness.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 310529091639,
             "good": false,
             "characters": []
@@ -5625,6 +6167,7 @@
             "season": 25,
             "episode": 13,
             "description": "Sideshow Bob genetically alters his DNA, giving him superhuman strength; Marge volunteers as a teen abstinence counselor.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 307207235909,
             "good": false,
             "characters": []
@@ -5634,6 +6177,7 @@
             "season": 25,
             "episode": 14,
             "description": "When the Simpsons allow members of the retirement community to move in with them, Marge worries that Homer is picking up their habits and is turning into an old man; a gang of bullies accepts Bart as one of their own.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 307209283970,
             "good": false,
             "characters": []
@@ -5643,6 +6187,7 @@
             "season": 25,
             "episode": 15,
             "description": "Homer convinces Marge to sell a painting that was purchased from Milhouse's parents at a yard sale, a painting that turns out to be worth a great deal of money.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 311117891947,
             "good": false,
             "characters": []
@@ -5652,6 +6197,7 @@
             "season": 25,
             "episode": 16,
             "description": "After Lisa delivers a school report on why her father is her hero, Homer is tapped to referee World Cup soccer in Brazil.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 304489539783,
             "good": false,
             "characters": []
@@ -5661,6 +6207,7 @@
             "season": 25,
             "episode": 17,
             "description": "Lisa falls for a competitive eater who subconsciously reminds her of Homer; after Bart hides Jailbird from the police, he begins receiving stolen gifts.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 304500803520,
             "good": false,
             "characters": []
@@ -5670,6 +6217,7 @@
             "season": 25,
             "episode": 18,
             "description": "Thirty years in the future, Bart tries to reestablish his relationship with his estranged wife, Jenda; Lisa thinks Milhouse is far more interesting after he's bitten by a zombie.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 310257731892,
             "good": false,
             "characters": []
@@ -5679,6 +6227,7 @@
             "season": 25,
             "episode": 19,
             "description": "Bart uses voodoo in an attempt to get rid of an art teacher, but when the teacher ends up getting pregnant, word spreads that Bart can help couples conceive.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 307214403888,
             "good": false,
             "characters": []
@@ -5688,6 +6237,7 @@
             "season": 25,
             "episode": 20,
             "description": "After Homer bonds with Lisa, Homer's imagination creates a world in which everything is made of Lego toys.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 311243331763,
             "good": false,
             "characters": []
@@ -5697,6 +6247,7 @@
             "season": 25,
             "episode": 21,
             "description": "As Mother's Day approaches, after Homer and Marge's attempt to befriend other couples fails miserably, Lisa discovers a shocking secret about her new best friend.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 304502851923,
             "good": false,
             "characters": []
@@ -5706,6 +6257,7 @@
             "season": 25,
             "episode": 22,
             "description": "Bart is overcome with guilt after an act of cowardice leads to his winning a school race; Homer vows to hold his own Fourth of July fireworks display after Springfield's holiday celebration is canceled.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 307219523604,
             "good": false,
             "characters": []
@@ -5715,6 +6267,7 @@
             "season": 25,
             "episode": 25,
             "description": "A theatrical short that premiered July 13, 2012, attached to the theatrical release of Ice Age: Continental Drift.  It was nominated for an Academy Award for Best Animated Short.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 588949571786,
             "good": false,
             "characters": []
@@ -5724,6 +6277,7 @@
             "season": 26,
             "episode": 1,
             "description": "The unthinkable happens: a Springfield resident dies.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 334920771636,
             "good": false,
             "characters": [
@@ -5735,6 +6289,7 @@
             "season": 26,
             "episode": 2,
             "description": "Homer and Bart set sail on the relation ship.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 346737219924,
             "good": false,
             "characters": [
@@ -5747,6 +6302,7 @@
             "season": 26,
             "episode": 3,
             "description": "Marge opens a sandwich shop.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 340536899599,
             "good": false,
             "characters": [
@@ -5758,6 +6314,7 @@
             "season": 26,
             "episode": 4,
             "description": "Don't miss the all-new, spooktacular Halloween special, \"Treehouse of Horror XXV.\"",
+            "disneyplus_id": null,
             "simpsonsworld_id": 344255555880,
             "good": false,
             "characters": [
@@ -5769,6 +6326,7 @@
             "season": 26,
             "episode": 5,
             "description": "An all-new episode featuring guest voice Jane Fonda, whose character falls for Mr. Burns.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 351437379941,
             "good": false,
             "characters": [
@@ -5781,6 +6339,7 @@
             "season": 26,
             "episode": 6,
             "description": "The Simpsons travel to the 31st century.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 355593283530,
             "good": false,
             "characters": [
@@ -5792,6 +6351,7 @@
             "season": 26,
             "episode": 7,
             "description": "Bart faces a tough test at school when he gets a new teacher, Mr. Lassen, who vows to crush his spirit.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 359228483622,
             "good": false,
             "characters": [
@@ -5803,6 +6363,7 @@
             "season": 26,
             "episode": 8,
             "description": "Homer forms a cover band with some of the other dads in town.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 362239555757,
             "good": false,
             "characters": [
@@ -5815,6 +6376,7 @@
             "season": 26,
             "episode": 9,
             "description": "Marge doesn't approve of Homer's Christmas spirits.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 368212547872,
             "good": false,
             "characters": []
@@ -5824,6 +6386,7 @@
             "season": 26,
             "episode": 10,
             "description": "An amusement park ride lands the Simpsons in outer space..",
+            "disneyplus_id": null,
             "simpsonsworld_id": 379818563729,
             "good": false,
             "characters": []
@@ -5833,6 +6396,7 @@
             "season": 26,
             "episode": 11,
             "description": "Bart and Homer become BFF's.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 383002179865,
             "good": false,
             "characters": []
@@ -5842,6 +6406,7 @@
             "season": 26,
             "episode": 12,
             "description": "Homer becomes muse to Elon Musk.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 388773443652,
             "good": false,
             "characters": []
@@ -5851,6 +6416,7 @@
             "season": 26,
             "episode": 13,
             "description": "Springfield gets a new town anthem.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 395694659511,
             "good": false,
             "characters": []
@@ -5860,6 +6426,7 @@
             "season": 26,
             "episode": 14,
             "description": "Marge trades in her mom-chauffeur hat for a real one.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 399385667625,
             "good": false,
             "characters": []
@@ -5869,6 +6436,7 @@
             "season": 26,
             "episode": 15,
             "description": "Moe plots revenge over Nigerian e-mail scam.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 406163011894,
             "good": false,
             "characters": []
@@ -5878,6 +6446,7 @@
             "season": 26,
             "episode": 16,
             "description": "The Springfield congregation turns to gambling to repair the church.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 410018371522,
             "good": false,
             "characters": []
@@ -5887,6 +6456,7 @@
             "season": 26,
             "episode": 17,
             "description": "When Duffman undergoes hip replacement surgery and retires, the company sets up a reality show competition to find his replacement.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 420981315819,
             "good": false,
             "characters": []
@@ -5896,6 +6466,7 @@
             "season": 26,
             "episode": 18,
             "description": "Bart lies about being involved in a bulldozer crash, so Marge decides to follow him everywhere until he confesses.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 430426691868,
             "good": false,
             "characters": []
@@ -5905,6 +6476,7 @@
             "season": 26,
             "episode": 19,
             "description": "When Homer gets an old film roll developed, the family takes a trip down memory lane to see the origins of how Bart and Lisa first started fighting with each other.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 434682947703,
             "good": false,
             "characters": []
@@ -5914,6 +6486,7 @@
             "season": 26,
             "episode": 20,
             "description": "The Simpsons learn about Grampa's days in the Air Force, and Bart takes up smoking to impress Milhouse's Dutch cousin.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 438408259807,
             "good": false,
             "characters": [
@@ -5926,6 +6499,7 @@
             "season": 26,
             "episode": 21,
             "description": "After Bart gets bullied at the school dance, Marge convinces the town to pass anti-bullying legislation.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 442879555692,
             "good": false,
             "characters": []
@@ -5935,6 +6509,7 @@
             "season": 26,
             "episode": 22,
             "description": "When a modernized Springfield Elementary has a technical meltdown, Lisa transforms it into a Waldorf school.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 446649411760,
             "good": false,
             "characters": []
@@ -5944,6 +6519,7 @@
             "season": 27,
             "episode": 1,
             "description": "Marge decides it's finally time to separate from Homer, and quickly moves on with her life. Homer is initially devastated, but soon stumbles into a romance with a younger woman.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 770426947744,
             "good": false,
             "characters": [
@@ -5956,6 +6532,7 @@
             "season": 27,
             "episode": 2,
             "description": "A celebrity television chef challenges Homer to a barbecue cook-off. But before the competition, Homer's new, prized barbecue grill is stolen.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 770595395906,
             "good": false,
             "characters": [
@@ -5969,6 +6546,7 @@
             "season": 27,
             "episode": 3,
             "description": "Patty and Selma try to quit smoking, but Patty moves in with the Simpsons when Selma takes it up again. Meanwhile, Maggie goes on an adventure with some local creatures.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 772103747997,
             "good": false,
             "characters": [
@@ -5982,6 +6560,7 @@
             "season": 27,
             "episode": 4,
             "description": "The Simpsons are proud to be the most festively decorated house on the block. But when Lisa is traumatized at Krustyland Horror Night, she feels she cannot handle Halloween anymore.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 770425923947,
             "good": false,
             "characters": []
@@ -5991,6 +6570,7 @@
             "season": 27,
             "episode": 5,
             "description": "After killing Bart, Sideshow Bob doesn't know what to do with himself; Homer wakes up with short-term memory loss; Because of radiation, Lisa, Bart and Milhouse gain super-powers.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 770433091920,
             "good": false,
             "characters": [
@@ -6002,6 +6582,7 @@
             "season": 27,
             "episode": 6,
             "description": "Lisa makes a new friend at school - Harper, who happens to be super-rich, while Homer makes friends with Harper's dad and sets out to continue living the good life when Lisa decides to end the friendship.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 770437187884,
             "good": false,
             "characters": []
@@ -6011,6 +6592,7 @@
             "season": 27,
             "episode": 7,
             "description": "Broadway legend Laney Fontaine transforms Lisa into a show-biz kid after Homer loses her chance at band camp.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 770417219938,
             "good": false,
             "characters": []
@@ -6020,6 +6602,7 @@
             "season": 27,
             "episode": 8,
             "description": "Lisa tries to restore the reputation of a forgotten Springfield female inventor, while Bart takes full advantage of a diagnosis that he is a sociopath.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 770422339536,
             "good": false,
             "characters": []
@@ -6029,6 +6612,7 @@
             "season": 27,
             "episode": 9,
             "description": "A tale of Bart's journey from youth to adulthood, where he is constantly in search of approval from his father and in the shadow of his more-successful younger sister.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 1071531075851,
             "good": false,
             "characters": []
@@ -6038,6 +6622,7 @@
             "season": 27,
             "episode": 10,
             "description": "When Homer loses his job due to Marge's social media post, he begins working as a dishwasher at a Greek restaurant. Meanwhile, Lisa creates an app that can predict the effect any post on social media will have.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 770434627559,
             "good": false,
             "characters": []
@@ -6047,6 +6632,7 @@
             "season": 27,
             "episode": 11,
             "description": "Bart and Principal Skinner battle over the affection of Bart's new teacher, and a new milk-based product that Homer buys from the Kwik-E-Mart causes big changes in Bart and Lisa.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 770430019813,
             "good": false,
             "characters": []
@@ -6056,6 +6642,7 @@
             "season": 27,
             "episode": 12,
             "description": "Apu's nephew makes big changes when he takes over the Kwik-E-Mart business, and Bart decides that he's through with being bad after his latest prank spirals out of control.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 770449475567,
             "good": false,
             "characters": []
@@ -6065,6 +6652,7 @@
             "season": 27,
             "episode": 13,
             "description": "Professor Frink's new invention turns him into a ladies' man, while a new pill at the Springfield Retirement Castle causes Grandpa to hallucinate back to his happiest moments.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 770439747712,
             "good": false,
             "characters": []
@@ -6074,6 +6662,7 @@
             "season": 27,
             "episode": 14,
             "description": "Lisa tries to launch the career of a homeless Appalachian folk singer, but Bart warns her that she will just let her down. Meanwhile, Homer tries to rescue the cat, who is trapped in the walls of the house.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 770451523845,
             "good": false,
             "characters": []
@@ -6083,6 +6672,7 @@
             "season": 27,
             "episode": 15,
             "description": "Lisa takes a job as veterinarian's assistant, but soon lets the responsibilities of the job get to her head. Meanwhile, Marge decides to take a job as a crime scene cleaner.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 770452547696,
             "good": false,
             "characters": []
@@ -6092,6 +6682,7 @@
             "season": 27,
             "episode": 16,
             "description": "Lisa signs up for an opportunity to be part of a mission to colonize Mars in ten years, and Homer's strategy to use reverse psychology to talk her out of it backfires.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 770891331927,
             "good": false,
             "characters": []
@@ -6101,6 +6692,7 @@
             "season": 27,
             "episode": 17,
             "description": "Homer tries to raise Smithers' spirits by finding him a man, and Lisa gets the lead in the school production of \"Casablanca\" alongside a new male student, sparking Millhouse's jealousy.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 770893891557,
             "good": false,
             "characters": []
@@ -6110,6 +6702,7 @@
             "season": 27,
             "episode": 18,
             "description": "After Lisa overhears Marge say that she doesn't like Lisa's jazz music, Marge takes Lisa on a trip to Capitol City to regain her friendship. Meanwhile, Bart uses Maggie as his new partner in crime for his practical jokes.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 770893891750,
             "good": false,
             "characters": []
@@ -6119,6 +6712,7 @@
             "season": 27,
             "episode": 19,
             "description": "Maggie will not go to sleep, so Homer tells her a bedtime story about when the Simpsons and the Flanders went together to the Grand Canyon.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 1071851075844,
             "good": false,
             "characters": []
@@ -6128,6 +6722,7 @@
             "season": 27,
             "episode": 20,
             "description": "After promising Marge the trip of a lifetime, Homer makes a deal with a travel agent to be a courier of a top-secret briefcase in exchange for a discounted family vacation to Paris.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 772102211921,
             "good": false,
             "characters": []
@@ -6137,6 +6732,7 @@
             "season": 27,
             "episode": 21,
             "description": "While trying to overcome a fear of public speaking, Homer creates an improv comedy troupe. Meanwhile, Marge rebuilds Bart's treehouse, but gets no thanks from him. Homer later appears live to answer phoned in questions.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 770892355976,
             "good": false,
             "characters": []
@@ -6146,6 +6742,7 @@
             "season": 27,
             "episode": 22,
             "description": "Marge lets Bart go to the park alone because he's too irritating, then she ends up getting arrested for leaving him unsupervised.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 772111939897,
             "good": false,
             "characters": []
@@ -6155,6 +6752,7 @@
             "season": 28,
             "episode": 1,
             "description": "Mr. Burns puts on a variety show at the Springfield Bowl.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 1066704963871,
             "good": false,
             "characters": [
@@ -6168,6 +6766,7 @@
             "season": 28,
             "episode": 2,
             "description": "Homer finds a new friend in a woman who acts just like him when Mr. Burns hires the other Simpsons as his live-in virtual reality family.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 1064038980002,
             "good": false,
             "characters": [
@@ -6181,6 +6780,7 @@
             "season": 28,
             "episode": 3,
             "description": "Homer takes the family on a \"hate-cation\" to Boston after he catches Bart rooting for a rival football team.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 1064043075512,
             "good": false,
             "characters": [
@@ -6192,6 +6792,7 @@
             "season": 28,
             "episode": 4,
             "description": "The children of Springfield fight to the death, Hunger Games style; Lisa's imaginary friend kills her real friends; Moe recruits Bart into his group of covert barfly agents.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 1063870531930,
             "good": false,
             "characters": [
@@ -6203,6 +6804,7 @@
             "season": 28,
             "episode": 5,
             "description": "Bart and Lisa investigate Krusty's new candy; Marge helps Homer dress for a promotion; Kent Brockman struggles with the changing media world.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 1064042051872,
             "good": false,
             "characters": []
@@ -6212,6 +6814,7 @@
             "season": 28,
             "episode": 6,
             "description": "Homer coaches the kids' lacrosse team with Kirk Van Houten, who disappears before the championship game, after Homer rants about him being a loser.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 1064041539874,
             "good": false,
             "characters": []
@@ -6221,6 +6824,7 @@
             "season": 28,
             "episode": 7,
             "description": "The Simpsons go to Cuba to get Grampa cheap medical care when the Retirement Castle and V.A. hospital are unable to solve his health problems.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 1064044099513,
             "good": false,
             "characters": []
@@ -6230,6 +6834,7 @@
             "season": 28,
             "episode": 8,
             "description": "Homer discovers an app that makes his life easier, while Grampa learns that he'll be a father again.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 1064046147533,
             "good": false,
             "characters": []
@@ -6239,6 +6844,7 @@
             "season": 28,
             "episode": 9,
             "description": "Homer is placed in a cast following a workplace accident, leading Marge to receive romance from an unexpected source; Lisa attempts to keep the peace as bus monitor.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 1064046147517,
             "good": false,
             "characters": []
@@ -6248,6 +6854,7 @@
             "season": 28,
             "episode": 10,
             "description": "Krusty and his daughter spend Christmas with the Simpsons; Reverend Lovejoy seeks converts to boost attendance at church; A Christmas toy scares Maggie.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 1064045635565,
             "good": false,
             "characters": []
@@ -6257,6 +6864,7 @@
             "season": 28,
             "episode": 11,
             "description": "A Japanese book on minimalism inspires Marge to adapt to a new way of living, so the Simpsons have to part with items that no longer bring them joy.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 1070436931706,
             "good": false,
             "characters": []
@@ -6266,6 +6874,7 @@
             "season": 28,
             "episode": 14,
             "description": "When all the fast food restaurants in Springfield become healthy, Homer turns to the last bastion of greasy food for comfort; Lisa must find a good news story when her school radio station is in jeopardy.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 1064044611770,
             "good": false,
             "characters": []
@@ -6275,6 +6884,7 @@
             "season": 28,
             "episode": 15,
             "description": "Bart deals with his guilt of betraying Lisa; Homer is revealed to be a master chess player.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 1064044611752,
             "good": false,
             "characters": []
@@ -6284,6 +6894,7 @@
             "season": 28,
             "episode": 16,
             "description": "Bart and Lisa return home following a traumatic incident at Kamp Krusty, putting an end to Homer and Marge's sexual encounters.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 1064043587996,
             "good": false,
             "characters": []
@@ -6293,6 +6904,7 @@
             "season": 28,
             "episode": 17,
             "description": "Bart becomes a star basketball player at Springfield Elementary.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 1064044099732,
             "good": false,
             "characters": []
@@ -6302,6 +6914,7 @@
             "season": 28,
             "episode": 18,
             "description": "As Homer and Marge try a different parenting style on Bart, Grampa gives him a special watch.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 1064046659528,
             "good": false,
             "characters": []
@@ -6311,6 +6924,7 @@
             "season": 28,
             "episode": 19,
             "description": "Mr. Burns starts his own for-profit university and hires Homer as a professor.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 1064044611790,
             "good": false,
             "characters": []
@@ -6320,6 +6934,7 @@
             "season": 28,
             "episode": 20,
             "description": "Bart befriends the grandmothers of Springfield.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 1064046659522,
             "good": false,
             "characters": []
@@ -6329,6 +6944,7 @@
             "season": 28,
             "episode": 21,
             "description": "Moe helps Homer and Marge work on their marriage.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 1064045635817,
             "good": false,
             "characters": []
@@ -6338,6 +6954,7 @@
             "season": 28,
             "episode": 22,
             "description": "The dogs of Springfield assert their dominance.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 1064045635799,
             "good": false,
             "characters": []
@@ -6347,6 +6964,7 @@
             "season": 28,
             "episode": 1213,
             "description": "Mr. Burns tries to relive his glory days, and crosses paths with a mysterious music mogul. After being conned by him and reduced to bankruptcy, Mr. Burns seeks revenge on the music producer.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 1077274179891,
             "good": false,
             "characters": []
@@ -6356,6 +6974,7 @@
             "season": 29,
             "episode": 1,
             "description": "In a world of magic, Marge's mother is transformed into an Ice Walker and must rely on Lisa to use magic to help Homer afford the cure.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 1075435075944,
             "good": false,
             "characters": []
@@ -6365,6 +6984,7 @@
             "season": 29,
             "episode": 2,
             "description": "Marge and Lisa decide to turns an unpleasant experience Lisa had into a successful graphic novel.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 1080357443795,
             "good": false,
             "characters": []
@@ -6374,6 +6994,7 @@
             "season": 29,
             "episode": 3,
             "description": "Homer stumbles upon Maggie's incredible talent for whistling and decides to start her on the path to becoming a baby celebrity.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 1073411651711,
             "good": false,
             "characters": []
@@ -6383,6 +7004,7 @@
             "season": 29,
             "episode": 4,
             "description": "Maggie's body is overwhelmed by the malice of an ancient demon; in an alternate dimension, Lisa stumbles upon a disturbingly perfect version of her family.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 1078509635693,
             "good": false,
             "characters": [
@@ -6394,6 +7016,7 @@
             "season": 29,
             "episode": 5,
             "description": "Grampa Simpson is finally able to hear the various things that people say about him after he receives a new hearing aid.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 1088584771605,
             "good": false,
             "characters": []
@@ -6403,6 +7026,7 @@
             "season": 29,
             "episode": 6,
             "description": "Marge decides to enter the race to become the next mayor of Springfield as she grows increasingly frustrated with how the local government operates.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 1094410819778,
             "good": false,
             "characters": []
@@ -6412,6 +7036,7 @@
             "season": 29,
             "episode": 7,
             "description": "Homer and the guys try helping Moe cheer up by getting their old bowling team back together again, but they soon face a team of arrogant millionaires.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 1099353155881,
             "good": false,
             "characters": []
@@ -6421,6 +7046,7 @@
             "season": 29,
             "episode": 8,
             "description": "In the future, Lisa works on writing her Harvard college application essay by reflecting on how certain disappointing birthdays made her who she is.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 1108700739531,
             "good": false,
             "characters": []
@@ -6430,6 +7056,7 @@
             "season": 29,
             "episode": 9,
             "description": "When Bart suddenly disappears, the town organizes a search party in the hopes of finding him.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 1113094211783,
             "good": false,
             "characters": []
@@ -6439,6 +7066,7 @@
             "season": 29,
             "episode": 10,
             "description": "While the Simpson family attends a STEM conference, Lisa becomes attracted to a pianist and Bart learns about his natural talent for chemistry.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 1131039811958,
             "good": false,
             "characters": []
@@ -6448,7 +7076,338 @@
             "season": 29,
             "episode": 11,
             "description": "When Mr. Burns begins to worry that the world is coming to an end, he starts testing all of the residents of to figure out who would be worth saving.",
+            "disneyplus_id": null,
             "simpsonsworld_id": 1136372803875,
+            "good": false,
+            "characters": []
+        },
+        {
+            "title": "Homer Is Where the Art Isn't",
+            "season": 29,
+            "episode": 12,
+            "description": "Homer learns to love a piece of art.",
+            "disneyplus_id": null,
+            "simpsonsworld_id": null,
+            "good": false,
+            "characters": []
+        },
+        {
+            "title": "3 Scenes Plus a Tag from a Marriage",
+            "season": 29,
+            "episode": 13,
+            "description": "The Simpsons visit their old apartment and remember the days without their kids.",
+            "disneyplus_id": null,
+            "simpsonsworld_id": null,
+            "good": false,
+            "characters": []
+        },
+        {
+            "title": "Fears of a Clown",
+            "season": 29,
+            "episode": 14,
+            "description": "Due to a general fear of clowns, Krusty can no longer do his job.",
+            "disneyplus_id": null,
+            "simpsonsworld_id": null,
+            "good": false,
+            "characters": []
+        },
+        {
+            "title": "No Good Read Goes Unpunished",
+            "season": 29,
+            "episode": 15,
+            "description": "Bart tries to conquer Homer with help from a book.",
+            "disneyplus_id": null,
+            "simpsonsworld_id": null,
+            "good": false,
+            "characters": []
+        },
+        {
+            "title": "King Leer",
+            "season": 29,
+            "episode": 16,
+            "description": "Moe inherits a mattress business from his father.",
+            "disneyplus_id": null,
+            "simpsonsworld_id": null,
+            "good": false,
+            "characters": []
+        },
+        {
+            "title": "Lisa Gets the Blues",
+            "season": 29,
+            "episode": 17,
+            "description": "The family goes to New Orleans where they try to recover from various traumas.",
+            "disneyplus_id": null,
+            "simpsonsworld_id": null,
+            "good": false,
+            "characters": []
+        },
+        {
+            "title": "Forgive and Regret",
+            "season": 29,
+            "episode": 18,
+            "description": "Grampa is about to die when he reveals a terrible secret.",
+            "disneyplus_id": null,
+            "simpsonsworld_id": null,
+            "good": false,
+            "characters": []
+        },
+        {
+            "title": "Left Behind",
+            "season": 29,
+            "episode": 19,
+            "description": "Flanders loses his business and works with Homer at the plant.",
+            "disneyplus_id": null,
+            "simpsonsworld_id": null,
+            "good": false,
+            "characters": []
+        },
+        {
+            "title": "Throw Grampa from the Dane",
+            "season": 29,
+            "episode": 20,
+            "description": "The Simpsons visit Denmark and everyone but Homer falls in love with the happy country.",
+            "disneyplus_id": null,
+            "simpsonsworld_id": null,
+            "good": false,
+            "characters": []
+        },
+        {
+            "title": "Flanders' Ladder",
+            "season": 29,
+            "episode": 21,
+            "description": "Bart is struck by lightning and has horrible dreams.",
+            "disneyplus_id": null,
+            "simpsonsworld_id": null,
+            "good": false,
+            "characters": []
+        },
+        {
+            "title": "Bart's Not Dead",
+            "season": 30,
+            "episode": 1,
+            "description": "Bart's cover for his lie backfires.",
+            "disneyplus_id": null,
+            "simpsonsworld_id": null,
+            "good": false,
+            "characters": []
+        },
+        {
+            "title": "Heartbreak Hotel",
+            "season": 30,
+            "episode": 2,
+            "description": "Homer and Marge go on an amazing race type show where they are eliminated immediately.",
+            "disneyplus_id": null,
+            "simpsonsworld_id": null,
+            "good": false,
+            "characters": []
+        },
+        {
+            "title": "My Way or the Highway to Heaven",
+            "season": 30,
+            "episode": 3,
+            "description": "The Simpsons explore three ways to get into heaven.",
+            "disneyplus_id": null,
+            "simpsonsworld_id": null,
+            "good": false,
+            "characters": []
+        },
+        {
+            "title": "Treehouse of Horror XXIX",
+            "season": 30,
+            "episode": 4,
+            "description": "The Simpsons battle spores from space and Grampa goes to a Jurassic Park-style senior home.",
+            "disneyplus_id": null,
+            "simpsonsworld_id": null,
+            "good": false,
+            "characters": []
+        },
+        {
+            "title": "Baby You Can't Drive My Car",
+            "season": 30,
+            "episode": 5,
+            "description": "Marge and Homer work together at a cool tech company.",
+            "disneyplus_id": null,
+            "simpsonsworld_id": null,
+            "good": false,
+            "characters": []
+        },
+        {
+            "title": "From Russia Without Love",
+            "season": 30,
+            "episode": 6,
+            "description": "Bart orders a Russian bride for Moe. She turns Moe's life around, and he falls in love.",
+            "disneyplus_id": null,
+            "simpsonsworld_id": null,
+            "good": false,
+            "characters": []
+        },
+        {
+            "title": "Werking Mom",
+            "season": 30,
+            "episode": 7,
+            "description": "Marge becomes a successful Tupperware saleswoman because customers think she's a man in drag.",
+            "disneyplus_id": null,
+            "simpsonsworld_id": null,
+            "good": false,
+            "characters": []
+        },
+        {
+            "title": "Krusty the Clown",
+            "season": 30,
+            "episode": 8,
+            "description": "Homer becomes an internet recapper while Krusty joins the circus.",
+            "disneyplus_id": null,
+            "simpsonsworld_id": null,
+            "good": false,
+            "characters": []
+        },
+        {
+            "title": "Daddicus Finch",
+            "season": 30,
+            "episode": 9,
+            "description": "Lisa reads \"To Kill a Mockingbird\" and observes similarities between her dad and Atticus Finch.",
+            "disneyplus_id": null,
+            "simpsonsworld_id": null,
+            "good": false,
+            "characters": []
+        },
+        {
+            "title": "'Tis the 30th Season",
+            "season": 30,
+            "episode": 10,
+            "description": "The Simpsons try to spend a relaxing Florida Christmas.",
+            "disneyplus_id": null,
+            "simpsonsworld_id": null,
+            "good": false,
+            "characters": []
+        },
+        {
+            "title": "Mad About the Toy",
+            "season": 30,
+            "episode": 11,
+            "description": "Grampa learns a startling secret from his past. It takes him to Texas to find a long-lost life.",
+            "disneyplus_id": null,
+            "simpsonsworld_id": null,
+            "good": false,
+            "characters": []
+        },
+        {
+            "title": "The Girl on the Bus",
+            "season": 30,
+            "episode": 12,
+            "description": "Lisa discovers the ideal family... and lies about her own.",
+            "disneyplus_id": null,
+            "simpsonsworld_id": null,
+            "good": false,
+            "characters": []
+        },
+        {
+            "title": "I'm Dancing as Fat as I Can",
+            "season": 30,
+            "episode": 13,
+            "description": "When Homer breaks a promise and binge watches a show without Marge, she is more furious than ever.",
+            "disneyplus_id": null,
+            "simpsonsworld_id": null,
+            "good": false,
+            "characters": []
+        },
+        {
+            "title": "The Clown Stays in the Picture",
+            "season": 30,
+            "episode": 14,
+            "description": "On a podcast Krusty discusses a lost film he made in the \u201880s.",
+            "disneyplus_id": null,
+            "simpsonsworld_id": null,
+            "good": false,
+            "characters": []
+        },
+        {
+            "title": "101 Mitigations",
+            "season": 30,
+            "episode": 15,
+            "description": "Homer goes on a joyride and is threatened with prison by Comic Book Guy.",
+            "disneyplus_id": null,
+            "simpsonsworld_id": null,
+            "good": false,
+            "characters": []
+        },
+        {
+            "title": "I Want You (She's So Heavy)",
+            "season": 30,
+            "episode": 16,
+            "description": "Homer gets an inguinal hernia which comes to life and tells him to take it easy.",
+            "disneyplus_id": null,
+            "simpsonsworld_id": null,
+            "good": false,
+            "characters": []
+        },
+        {
+            "title": "E My Sports",
+            "season": 30,
+            "episode": 17,
+            "description": "Bart earns money in a video game competition, and Homer becomes his coach.",
+            "disneyplus_id": null,
+            "simpsonsworld_id": null,
+            "good": false,
+            "characters": []
+        },
+        {
+            "title": "Bart vs. Itchy and Scratchy",
+            "season": 30,
+            "episode": 18,
+            "description": "Bart is upset to learn there is a new, all-girl version of Itchy and Scratchy.",
+            "disneyplus_id": null,
+            "simpsonsworld_id": null,
+            "good": false,
+            "characters": []
+        },
+        {
+            "title": "Girl's in the Band",
+            "season": 30,
+            "episode": 19,
+            "description": "Lisa joins an advanced youth orchestra in Capital City, throwing the family\u2019s lives into havoc.",
+            "disneyplus_id": null,
+            "simpsonsworld_id": null,
+            "good": false,
+            "characters": []
+        },
+        {
+            "title": "I'm Just a Girl Who Can't Say D'oh",
+            "season": 30,
+            "episode": 20,
+            "description": "Marge becomes director of a local theater production.",
+            "disneyplus_id": null,
+            "simpsonsworld_id": null,
+            "good": false,
+            "characters": []
+        },
+        {
+            "title": "D'oh Canada",
+            "season": 30,
+            "episode": 21,
+            "description": "Lisa goes to Canada and refuses to leave. A desperate Marge tries to get her back.",
+            "disneyplus_id": null,
+            "simpsonsworld_id": null,
+            "good": false,
+            "characters": []
+        },
+        {
+            "title": "Woo-Hoo Dunnit?",
+            "season": 30,
+            "episode": 22,
+            "description": "$600 theft rocks the Simpson home. A local TV crime show attempts to crack it to no avail.",
+            "disneyplus_id": null,
+            "simpsonsworld_id": null,
+            "good": false,
+            "characters": []
+        },
+        {
+            "title": "Crystal Blue-Haired Persuasion",
+            "season": 30,
+            "episode": 23,
+            "description": "Marge sells crystals and makes a fortune.",
+            "disneyplus_id": null,
+            "simpsonsworld_id": null,
             "good": false,
             "characters": []
         }

--- a/simpsons_data.json
+++ b/simpsons_data.json
@@ -5,7 +5,7 @@
             "season": 1,
             "episode": 1,
             "description": "Homer decides to gamble on a \"hunch\" at the dog track when his annual Christmas bonus is canceled.",
-            "disneyplus_id": null,
+            "disneyplus_id": "79529cd0-f1cf-4eec-8b1d-ea1e1b76043b",
             "simpsonsworld_id": 273376835817,
             "good": false,
             "characters": [
@@ -17,7 +17,7 @@
             "season": 1,
             "episode": 2,
             "description": "Bart is believed to be a genius after he switches I.Q. tests with brainy Martin Prince.",
-            "disneyplus_id": null,
+            "disneyplus_id": "250ca502-751e-4b37-a465-f8b518d76ced",
             "simpsonsworld_id": 283744835990,
             "good": false,
             "characters": [
@@ -29,7 +29,7 @@
             "season": 1,
             "episode": 3,
             "description": "Fired from his job at the Nuclear Power Plant, Homer decides to embark on a campaign to make all of Springfield safer.",
-            "disneyplus_id": null,
+            "disneyplus_id": "0e8e7f27-0ab2-495f-8254-d99d3c53ce4f",
             "simpsonsworld_id": 273381443699,
             "good": false,
             "characters": [
@@ -41,7 +41,7 @@
             "season": 1,
             "episode": 4,
             "description": "After attending the annual company picnic, Homer becomes jealous of fellow employees with 'normal' families.  He decides to enlist the aid of psychologist Marvin Monroe to treat his wife and children.",
-            "disneyplus_id": null,
+            "disneyplus_id": "5e837a36-5db0-451c-82d3-0cca1490f784",
             "simpsonsworld_id": 273392195780,
             "good": true,
             "characters": [

--- a/test_build.py
+++ b/test_build.py
@@ -3,7 +3,7 @@
 """A series of asserts to verify data quality."""
 import json
 
-expected_ep_keys = ['title', 'season', 'episode', 'description',
+expected_ep_keys = ['title', 'season', 'episode', 'description', 'disneyplus_id',
                     'simpsonsworld_id', 'good', 'characters']
 expected_char_keys = ['name', 'short_name']
 
@@ -20,7 +20,7 @@ with open('simpsons_data.json', 'r') as f:
 
     for episode in all_episodes:
         # Should have expected keys
-        # print(f"#{episode['sea/son']} - #{episode['episode']}")
+        # print(f"#{episode['season']} - #{episode['episode']}")
         for key in expected_ep_keys:
             assert key in episode
         assert len(expected_ep_keys) == len(episode.keys())
@@ -40,8 +40,13 @@ with open('simpsons_data.json', 'r') as f:
         # Description should be a string
         assert isinstance(episode['description'], str)
 
-        # Simpsonsworld ID should be an int
-        assert isinstance(episode['simpsonsworld_id'], int)
+        # Simpsonsworld ID should be a str if set
+        if episode['disneyplus_id']:
+            assert isinstance(episode['disneyplus_id'], str)
+
+        # Simpsonsworld ID should be an int if set
+        if episode['simpsonsworld_id']:
+            assert isinstance(episode['simpsonsworld_id'], int)
 
         # Good should be a boolean
         assert isinstance(episode['good'], bool)


### PR DESCRIPTION
Add the D+ key to everything, and populates it for a few season 1 episodes.

I had hoped D+ would expose episode IDs like SW did, but they don't, so we'll have to write a selenium script or imacro or something like that to mass get those URLs (I don't know if I feel like doing this 650 times by hand). rude tbh!