### PR TITLE
Add D+ ids for S24-26

### DIFF
--- a/episodes/season_24.yml
+++ b/episodes/season_24.yml
@@ -6,7 +6,7 @@ episodes:
   description: Bart seeks out Cletus's daughter, who has started a new life in New
     York City, Lisa wants to take in a Broadway play but ends up performing Shakespeare
     in Central Park.
-  disneyplus_id:
+  disneyplus_id: 15a66ce2-69d0-4f64-9d8b-dfd5d05111c0
   simpsonsworld_id: 221691971633
   good: maybe
   characters:
@@ -16,7 +16,7 @@ episodes:
   description: In these three Halloween tales... a black hole threatens to destroy
     Springfield; the Simpsons are terrorized by the unknown in a spoof of 'Paranormal
     Activity'; Bart time travels in a spoof of 'Back to the Future.'
-  disneyplus_id:
+  disneyplus_id: 1e683629-3099-4342-b9cd-830b67a607b2
   simpsonsworld_id: 221695555645
   good: true
   characters:
@@ -26,7 +26,7 @@ episodes:
   episode: 3
   description: Marge decides she wants to conceive another child; Bart realizes Lisa
     is up to something mysterious and vows to find out what it is.
-  disneyplus_id:
+  disneyplus_id: 4e9dc8fc-19c1-493a-bcb5-d2cd463512ed
   simpsonsworld_id: 221688899646
   good: maybe
   characters:
@@ -35,7 +35,7 @@ episodes:
   episode: 4
   description: Homer and Marge search for Grampa after he disappears from the retirement
     home; Homer invests Lisa's college fund in an online poker Web site.
-  disneyplus_id:
+  disneyplus_id: 95a59aa7-8dd8-4b37-946d-ba4b2370fe1b
   simpsonsworld_id: 221688899887
   good: maybe
   characters:
@@ -44,7 +44,7 @@ episodes:
   episode: 5
   description: While serving jury duty, Fat Tony appoints an accountant as his temporary
     Don; an anemic Lisa eats bugs to increase her iron level.
-  disneyplus_id:
+  disneyplus_id: 2364e35d-b013-4ce2-8781-2528238ca84a
   simpsonsworld_id: 221694531617
   good: maybe
   characters:
@@ -54,7 +54,7 @@ episodes:
   description: After his beloved new tablet "MyPad" computer is destroyed, a despondent
     Homer finds solace in a message seemingly written by God - until newsman Kent
     Brockman sets out to debunk the "miracle."
-  disneyplus_id:
+  disneyplus_id: 13091b84-3bf8-49b1-a289-1196270e20c5
   simpsonsworld_id: 229733443727
   good: maybe
   characters:
@@ -63,7 +63,7 @@ episodes:
   episode: 7
   description: Homer is elated when a cool dad and his family move next door, but
     his happiness ends when he realizes he has little in common with his new neighbors.
-  disneyplus_id:
+  disneyplus_id: 9f181a16-923c-4b5f-b16c-6ed616dbd5bf
   simpsonsworld_id: 222374467937
   good: maybe
   characters:
@@ -73,7 +73,7 @@ episodes:
   description: When Bart accuses Homer of not liking Santa's Little Helper, Grampa
     recounts the story of how Homer's heart broke after he was forced to give away
     his childhood dog.
-  disneyplus_id:
+  disneyplus_id: 31835d74-90cf-407d-a5b4-5cfdf65364dd
   simpsonsworld_id: 222491715618
   good: maybe
   characters:
@@ -82,7 +82,7 @@ episodes:
   episode: 9
   description: The Simpsons anticipate the apocalypse after Homer inadvertently triggers
     a shockwave that disables all electronic devices in Springfield.
-  disneyplus_id:
+  disneyplus_id: e5ab93cc-8b25-4f41-ba33-618cd72303f1
   simpsonsworld_id: 1094312515873
   good: maybe
   characters:
@@ -91,7 +91,7 @@ episodes:
   episode: 10
   description: Bart must pass a district-wide test to save Springfield Elementary;
     Homer uses a discarded parking meter to steal from unsuspecting drivers.
-  disneyplus_id:
+  disneyplus_id: 9d7c7493-3f24-4913-9982-af323ebc6a25
   simpsonsworld_id: 222388291945
   good: maybe
   characters:
@@ -100,7 +100,7 @@ episodes:
   episode: 11
   description: After narrowly surviving a tornado, Marge and Homer embark on a search
     for a couple who'll serve as Bart, Lisa and Maggie's legal guardians.
-  disneyplus_id:
+  disneyplus_id: b4979e57-2149-444f-a2ef-ffb99cad5fac
   simpsonsworld_id: 257684035668
   good: maybe
   characters:
@@ -109,7 +109,7 @@ episodes:
   episode: 12
   description: Bart attempts to patch things up with his old sweetheart, Mary Spuckler,
     and despite Lisa's input, still manages to sabotage his chances of finding love.
-  disneyplus_id:
+  disneyplus_id: 680107c6-aa55-49d7-aad6-6e2260625b65
   simpsonsworld_id: 257681987573
   good: maybe
   characters:
@@ -118,7 +118,7 @@ episodes:
   episode: 13
   description: With Bart's help, Milhouse transforms into his father; Homer discovers
     a talent for finding things in hidden-picture books.
-  disneyplus_id:
+  disneyplus_id: 9b94d4eb-f41a-4c7b-af02-75b13d18fa01
   simpsonsworld_id: 257686595928
   good: maybe
   characters:
@@ -128,7 +128,7 @@ episodes:
   description: With encouragement from Mr. Burns, Grampa revives a famous wrestling
     character from his past whom audiences love to hate, and despite Homer and Marge's
     objections, incorporates Bart into the act.
-  disneyplus_id:
+  disneyplus_id: 637c1f7b-b52b-4ac1-8a2b-781cc6254fdb
   simpsonsworld_id: 257687107857
   good: maybe
   characters:
@@ -138,7 +138,7 @@ episodes:
   description: When Flanders gives Homer a black eye, he turns to the Bible for answers;
     Lisa is shocked and puzzled when she discovers that a substitute teacher hates
     her.
-  disneyplus_id:
+  disneyplus_id: 50ca0957-7857-490c-8a02-91daa99ec26c
   simpsonsworld_id: 257689667578
   good: maybe
   characters:
@@ -148,7 +148,7 @@ episodes:
   description: Bart stands trial in youth court after he's accused of pulling an Easter
     prank; after buying a comic book collection, Mr. Burns transforms into a 'Batman'-like
     superhero.
-  disneyplus_id:
+  disneyplus_id: 56b4c00a-9a1d-4e34-95ee-fb57416428e7
   simpsonsworld_id: 257714243647
   good: maybe
   characters:
@@ -157,7 +157,7 @@ episodes:
   episode: 17
   description: In an episode that focuses on the choices people make and their outcomes...
     Homer attempts to save his marriage; Milhouse woos Lisa.
-  disneyplus_id:
+  disneyplus_id: 6b63cb85-0417-4763-badc-cfe3abcafe10
   simpsonsworld_id: 1094243907551
   good: maybe
   characters:
@@ -166,7 +166,7 @@ episodes:
   episode: 18
   description: Lovejoy quits the church after the Parson appoints a charismatic reverend
     to reinvigorate the parish; Marge tracks down her old wedding dress.
-  disneyplus_id:
+  disneyplus_id: d7de92f2-f378-4328-86fd-1ba45b27e794
   simpsonsworld_id: 257728579751
   good: maybe
   characters:
@@ -176,7 +176,7 @@ episodes:
   description: Moe's new suit catches the attention of venture capitalists, leading
     to the distribution of Moe's own brand of whiskey; Bart cares for Grampa; Lisa
     realizes that her favorite musicians have been turned into holograms.
-  disneyplus_id:
+  disneyplus_id: 19842aab-5cbb-4b3f-a454-f519c3927f5e
   simpsonsworld_id: 257737283653
   good: maybe
   characters:
@@ -185,7 +185,7 @@ episodes:
   episode: 20
   description: Bart takes piano lessons in hopes of impressing his beautiful young
     teacher; Homer goes completely bald; Marge teaches a Russian man how to drive.
-  disneyplus_id:
+  disneyplus_id: 44088609-5b17-4aa8-90f3-3ccbec6a5fdb
   simpsonsworld_id: 257760323921
   good: maybe
   characters:
@@ -194,7 +194,7 @@ episodes:
   episode: 21
   description: Homer, Moe and Lenny travel to Iceland to retrieve lottery winnings
     that Carl ran off with.
-  disneyplus_id:
+  disneyplus_id: 407d6ec8-d258-4dc3-827c-a81cf50c8828
   simpsonsworld_id: 257753667515
   good: maybe
   characters:
@@ -203,7 +203,7 @@ episodes:
   episode: 22
   description: Homer secretly reconstructs a kiddy train as Marge's anniversary present;
     Marge attracts the attention of a potential paramour online.
-  disneyplus_id:
+  disneyplus_id: 7220ab72-469d-4ce0-a41e-d727c10e72c4
   simpsonsworld_id: 257768003795
   good: maybe
   characters:

--- a/episodes/season_25.yml
+++ b/episodes/season_25.yml
@@ -6,7 +6,7 @@ episodes:
   description: When Homer returns from a Nuclear Workers Convention and begins behaving
     strangely, Lisa worries that her father has been brainwashed and is now part of
     a terrorist plot to blow up the power plant.
-  disneyplus_id:
+  disneyplus_id: 52c632a3-fbc8-4d17-b46a-f5522ff30aaa
   simpsonsworld_id: 307191875741
   good: maybe
   characters:
@@ -16,7 +16,7 @@ episodes:
   description: In three terrifying Halloween tales, Bart, Lisa and Maggie receive
     a visit from The Fat in the Hat; when Bart is decapitated, his head is sewn onto
     Lisa's body; Homer plots to kill Moe at a circus freak show.
-  disneyplus_id:
+  disneyplus_id: 3ae51e62-c577-40cc-83fc-147cc4feccbf
   simpsonsworld_id: 310259779794
   good: maybe
   characters:
@@ -27,7 +27,7 @@ episodes:
   description: A Springfield funeral prompts Marge, Kent Brockman, Homer and Mr. Burns
     to reexamine a crucial decision in their lives one that has brought them the most
     regret.
-  disneyplus_id:
+  disneyplus_id: 166cebad-4ef0-404a-93ef-50166b7b847f
   simpsonsworld_id: 311688259548
   good: maybe
   characters:
@@ -37,7 +37,7 @@ episodes:
   description: After experiencing a midlife crisis, Homer reaches out to an old pen
     pal; when a cheating scandal rocks Springfield Elementary, Lisa establishes an
     honor code.
-  disneyplus_id:
+  disneyplus_id: 6b167486-d4b7-46c5-8246-2b24415d880a
   simpsonsworld_id: 304473155645
   good: maybe
   characters:
@@ -47,7 +47,7 @@ episodes:
   description: Homer gets trapped in an elevator with a pregnant woman and helps deliver
     her baby; Lisa helps underpaid cheerleaders organize so they can demand a salary
     increase from a greedy football team owner.
-  disneyplus_id:
+  disneyplus_id: 3ddd2387-3e2b-45d5-8003-075420c52ca9
   simpsonsworld_id: 311105091548
   good: maybe
   characters:
@@ -56,7 +56,7 @@ episodes:
   episode: 6
   description: Lisa is elated to befriend Isabel, a smart new student at school, only
     to realize that she and Isabel are on opposite sides of the political spectrum.
-  disneyplus_id:
+  disneyplus_id: 4b47c46b-cbda-4ecd-8715-94935ca69273
   simpsonsworld_id: 310523971648
   good: maybe
   characters:
@@ -66,7 +66,7 @@ episodes:
   description: Bart seeks revenge after Skinner prevents him from attending a school
     field trip aboard a submarine; Lisa suggests to the financially-strapped Krusty
     that he sell the foreign rights to his television show.
-  disneyplus_id:
+  disneyplus_id: febd486b-544e-4063-9f74-2925554c20a4
   simpsonsworld_id: 304476739664
   good: maybe
   characters:
@@ -76,7 +76,7 @@ episodes:
   description: As Christmas approaches, Marge transforms the house into a bed and
     breakfast after Springfield becomes the only town in America to receive snowfall;
     Lisa vows to give her loved ones modest gifts that come from the heart.
-  disneyplus_id:
+  disneyplus_id: 90d36b9f-c9da-4f5b-9c99-03f63a2742aa
   simpsonsworld_id: 307199043880
   good: maybe
   characters:
@@ -85,7 +85,7 @@ episodes:
   episode: 9
   description: Homer is put on trial after the FBI catches him illegally downloading
     movies from the Internet.
-  disneyplus_id:
+  disneyplus_id: 0c9550cd-8044-4efe-8eed-aece092047f6
   simpsonsworld_id: 310523459925
   good: maybe
   characters:
@@ -94,7 +94,7 @@ episodes:
   episode: 10
   description: The Comic Book Guy marries a Japanese woman, only to discover that
     the woman's father disapproves of the union.
-  disneyplus_id:
+  disneyplus_id: c26f25f7-d8d3-4ea0-a62a-bcaaa8688b3f
   simpsonsworld_id: 310541379637
   good: maybe
   characters:
@@ -103,26 +103,26 @@ episodes:
   episode: 11
   description: Homer uses augmented reality glasses to spy on Marge; Nelson demands
     a Valentine's Day card from Bart.
-  disneyplus_id:
+  disneyplus_id: 0c4e2f05-97c8-46fd-9699-6f44940717b7
   simpsonsworld_id: 307204163997
-  good: maybe
-  characters:
-- title: Diggs
-  season: 25
-  episode: 12
-  description: Bart befriends a fellow student and falconry expert, only to discover
-    that the boy suffers from mental illness.
-  disneyplus_id:
-  simpsonsworld_id: 310529091639
   good: maybe
   characters:
 - title: The Man Who Grew Too Much
   season: 25
-  episode: 13
+  episode: 12
   description: Sideshow Bob genetically alters his DNA, giving him superhuman strength;
     Marge volunteers as a teen abstinence counselor.
-  disneyplus_id:
+  disneyplus_id: 3afb3c6d-f176-4867-a1d1-c59758d9352b
   simpsonsworld_id: 307207235909
+  good: maybe
+  characters:
+- title: Diggs
+  season: 25
+  episode: 13
+  description: Bart befriends a fellow student and falconry expert, only to discover
+    that the boy suffers from mental illness.
+  disneyplus_id: 9afafaa3-fa10-489b-9b30-8e95371eb8ac
+  simpsonsworld_id: 310529091639
   good: maybe
   characters:
 - title: The Winter of His Content
@@ -131,7 +131,7 @@ episodes:
   description: When the Simpsons allow members of the retirement community to move
     in with them, Marge worries that Homer is picking up their habits and is turning
     into an old man; a gang of bullies accepts Bart as one of their own.
-  disneyplus_id:
+  disneyplus_id: bb32c897-8d50-495c-bce2-a9e91c4cc25b
   simpsonsworld_id: 307209283970
   good: maybe
   characters:
@@ -141,7 +141,7 @@ episodes:
   description: Homer convinces Marge to sell a painting that was purchased from Milhouse's
     parents at a yard sale, a painting that turns out to be worth a great deal of
     money.
-  disneyplus_id:
+  disneyplus_id: d589791f-8d39-40bc-a438-ef791f0fe4a8
   simpsonsworld_id: 311117891947
   good: maybe
   characters:
@@ -150,7 +150,7 @@ episodes:
   episode: 16
   description: After Lisa delivers a school report on why her father is her hero,
     Homer is tapped to referee World Cup soccer in Brazil.
-  disneyplus_id:
+  disneyplus_id: 7c3c7706-d070-4262-b4d6-21ce7e22899b
   simpsonsworld_id: 304489539783
   good: maybe
   characters:
@@ -159,7 +159,7 @@ episodes:
   episode: 17
   description: Lisa falls for a competitive eater who subconsciously reminds her of
     Homer; after Bart hides Jailbird from the police, he begins receiving stolen gifts.
-  disneyplus_id:
+  disneyplus_id: 6d255409-bf57-40b6-bbc1-307bebde5538
   simpsonsworld_id: 304500803520
   good: maybe
   characters:
@@ -169,7 +169,7 @@ episodes:
   description: Thirty years in the future, Bart tries to reestablish his relationship
     with his estranged wife, Jenda; Lisa thinks Milhouse is far more interesting after
     he's bitten by a zombie.
-  disneyplus_id:
+  disneyplus_id: 9089df85-7fd5-4fad-9e1b-5f4e8c2a7822
   simpsonsworld_id: 310257731892
   good: maybe
   characters:
@@ -179,7 +179,7 @@ episodes:
   description: Bart uses voodoo in an attempt to get rid of an art teacher, but when
     the teacher ends up getting pregnant, word spreads that Bart can help couples
     conceive.
-  disneyplus_id:
+  disneyplus_id: 1042e57d-5c33-44a5-a3bf-03ed298ea748
   simpsonsworld_id: 307214403888
   good: maybe
   characters:
@@ -188,7 +188,7 @@ episodes:
   episode: 20
   description: After Homer bonds with Lisa, Homer's imagination creates a world in
     which everything is made of Lego toys.
-  disneyplus_id:
+  disneyplus_id: 44ece42c-b05f-4368-91c4-ad72a5d23f61
   simpsonsworld_id: 311243331763
   good: maybe
   characters:
@@ -198,7 +198,7 @@ episodes:
   description: As Mother's Day approaches, after Homer and Marge's attempt to befriend
     other couples fails miserably, Lisa discovers a shocking secret about her new
     best friend.
-  disneyplus_id:
+  disneyplus_id: c4b37972-da8c-4268-b348-668474719dc3
   simpsonsworld_id: 304502851923
   good: maybe
   characters:
@@ -208,17 +208,7 @@ episodes:
   description: Bart is overcome with guilt after an act of cowardice leads to his
     winning a school race; Homer vows to hold his own Fourth of July fireworks display
     after Springfield's holiday celebration is canceled.
-  disneyplus_id:
+  disneyplus_id: ad75b189-ba84-41a8-af62-098025711897
   simpsonsworld_id: 307219523604
-  good: maybe
-  characters:
-- title: The Longest Daycare
-  season: 25
-  episode: 25
-  description: 'A theatrical short that premiered July 13, 2012, attached to the theatrical
-    release of Ice Age: Continental Drift.  It was nominated for an Academy Award
-    for Best Animated Short.'
-  disneyplus_id:
-  simpsonsworld_id: 588949571786
   good: maybe
   characters:

--- a/episodes/season_26.yml
+++ b/episodes/season_26.yml
@@ -4,7 +4,7 @@ episodes:
   season: 26
   episode: 1
   description: 'The unthinkable happens: a Springfield resident dies.'
-  disneyplus_id:
+  disneyplus_id: 254b91ea-02ed-4b16-aa4e-03b594b89288
   simpsonsworld_id: 334920771636
   good: false
   characters:
@@ -13,7 +13,7 @@ episodes:
   season: 26
   episode: 2
   description: Homer and Bart set sail on the relation ship.
-  disneyplus_id:
+  disneyplus_id: 6a793d21-929a-410a-8615-3f4444970e19
   simpsonsworld_id: 346737219924
   good: false
   characters:
@@ -23,7 +23,7 @@ episodes:
   season: 26
   episode: 3
   description: Marge opens a sandwich shop.
-  disneyplus_id:
+  disneyplus_id: c8a58eb9-dbab-471a-86b3-a04bc34c2cff
   simpsonsworld_id: 340536899599
   good: false
   characters:
@@ -33,7 +33,7 @@ episodes:
   episode: 4
   description: Don't miss the all-new, spooktacular Halloween special, "Treehouse
     of Horror XXV."
-  disneyplus_id:
+  disneyplus_id: 54d99d91-e952-4ff5-baf8-9eef1a054885
   simpsonsworld_id: 344255555880
   good: false
   characters:
@@ -43,7 +43,7 @@ episodes:
   episode: 5
   description: An all-new episode featuring guest voice Jane Fonda, whose character
     falls for Mr. Burns.
-  disneyplus_id:
+  disneyplus_id: 0d02c072-ec15-4e51-b0eb-b0a8c683abd7
   simpsonsworld_id: 351437379941
   good: false
   characters:
@@ -53,7 +53,7 @@ episodes:
   season: 26
   episode: 6
   description: The Simpsons travel to the 31st century.
-  disneyplus_id:
+  disneyplus_id: 4374e696-9cb9-4e95-b906-e623ad31593a
   simpsonsworld_id: 355593283530
   good: false
   characters:
@@ -63,7 +63,7 @@ episodes:
   episode: 7
   description: Bart faces a tough test at school when he gets a new teacher, Mr. Lassen,
     who vows to crush his spirit.
-  disneyplus_id:
+  disneyplus_id: 34716532-5c16-4b0a-97fd-d71a2807f87a
   simpsonsworld_id: 359228483622
   good: false
   characters:
@@ -72,7 +72,7 @@ episodes:
   season: 26
   episode: 8
   description: Homer forms a cover band with some of the other dads in town.
-  disneyplus_id:
+  disneyplus_id: a1ed36d5-3086-49b8-b83e-2d20e72fa12b
   simpsonsworld_id: 362239555757
   good: false
   characters:
@@ -82,7 +82,7 @@ episodes:
   season: 26
   episode: 9
   description: Marge doesn't approve of Homer's Christmas spirits.
-  disneyplus_id:
+  disneyplus_id: 16914d01-b98b-4cf2-8904-36bd8f651e8f
   simpsonsworld_id: 368212547872
   good: maybe
   characters:
@@ -90,7 +90,7 @@ episodes:
   season: 26
   episode: 10
   description: An amusement park ride lands the Simpsons in outer space..
-  disneyplus_id:
+  disneyplus_id: ea171ef8-0dab-48f9-bec1-491775080bc4
   simpsonsworld_id: 379818563729
   good: maybe
   characters:
@@ -98,7 +98,7 @@ episodes:
   season: 26
   episode: 11
   description: Bart and Homer become BFF's.
-  disneyplus_id:
+  disneyplus_id: b30df722-986c-46ba-8e51-be92095b6e17
   simpsonsworld_id: 383002179865
   good: maybe
   characters:
@@ -106,7 +106,7 @@ episodes:
   season: 26
   episode: 12
   description: Homer becomes muse to Elon Musk.
-  disneyplus_id:
+  disneyplus_id: 2ee937da-4304-4ca5-868d-472e189d942d
   simpsonsworld_id: 388773443652
   good: maybe
   characters:
@@ -114,7 +114,7 @@ episodes:
   season: 26
   episode: 13
   description: Springfield gets a new town anthem.
-  disneyplus_id:
+  disneyplus_id: 645c035f-4f8f-4422-884e-333889eae9f4
   simpsonsworld_id: 395694659511
   good: maybe
   characters:
@@ -122,7 +122,7 @@ episodes:
   season: 26
   episode: 14
   description: Marge trades in her mom-chauffeur hat for a real one.
-  disneyplus_id:
+  disneyplus_id: ff549ddd-2534-4769-9c8e-940e46363649
   simpsonsworld_id: 399385667625
   good: maybe
   characters:
@@ -130,7 +130,7 @@ episodes:
   season: 26
   episode: 15
   description: Moe plots revenge over Nigerian e-mail scam.
-  disneyplus_id:
+  disneyplus_id: 77a22172-c5a9-4c80-b5ff-3d8fe21ecc3b
   simpsonsworld_id: 406163011894
   good: maybe
   characters:
@@ -138,7 +138,7 @@ episodes:
   season: 26
   episode: 16
   description: The Springfield congregation turns to gambling to repair the church.
-  disneyplus_id:
+  disneyplus_id: 7571103b-40e7-4456-80b6-4d1856bc73b0
   simpsonsworld_id: 410018371522
   good: maybe
   characters:
@@ -147,7 +147,7 @@ episodes:
   episode: 17
   description: When Duffman undergoes hip replacement surgery and retires, the company
     sets up a reality show competition to find his replacement.
-  disneyplus_id:
+  disneyplus_id: 8a3b1f5a-338d-4a7c-afcf-e3bb3933d0bb
   simpsonsworld_id: 420981315819
   good: maybe
   characters:
@@ -156,7 +156,7 @@ episodes:
   episode: 18
   description: Bart lies about being involved in a bulldozer crash, so Marge decides
     to follow him everywhere until he confesses.
-  disneyplus_id:
+  disneyplus_id: 7570ff99-2fd0-47a3-b275-404c5b96cc10
   simpsonsworld_id: 430426691868
   good: maybe
   characters:
@@ -166,7 +166,7 @@ episodes:
   description: When Homer gets an old film roll developed, the family takes a trip
     down memory lane to see the origins of how Bart and Lisa first started fighting
     with each other.
-  disneyplus_id:
+  disneyplus_id: 240cf703-b203-40ce-83b3-150fa2bc7b06
   simpsonsworld_id: 434682947703
   good: maybe
   characters:
@@ -175,7 +175,7 @@ episodes:
   episode: 20
   description: The Simpsons learn about Grampa's days in the Air Force, and Bart takes
     up smoking to impress Milhouse's Dutch cousin.
-  disneyplus_id:
+  disneyplus_id: 6398510e-4e51-4a48-a538-5781de70918b
   simpsonsworld_id: 438408259807
   good: false
   characters:
@@ -186,7 +186,7 @@ episodes:
   episode: 21
   description: After Bart gets bullied at the school dance, Marge convinces the town
     to pass anti-bullying legislation.
-  disneyplus_id:
+  disneyplus_id: 677ab214-4cde-4a05-8767-369f7a59be8c
   simpsonsworld_id: 442879555692
   good: maybe
   characters:
@@ -195,7 +195,7 @@ episodes:
   episode: 22
   description: When a modernized Springfield Elementary has a technical meltdown,
     Lisa transforms it into a Waldorf school.
-  disneyplus_id:
+  disneyplus_id: ee46a17f-b96f-4db1-b8bf-0e25d09f9a59
   simpsonsworld_id: 446649411760
   good: maybe
   characters:

--- a/episodes/season_theatrical.yml
+++ b/episodes/season_theatrical.yml
@@ -1,0 +1,12 @@
+---
+episodes:
+- title: The Longest Daycare
+  season: 25
+  episode: 25
+  description: 'A theatrical short that premiered July 13, 2012, attached to the theatrical
+    release of Ice Age: Continental Drift.  It was nominated for an Academy Award
+    for Best Animated Short.'
+  disneyplus_id:
+  simpsonsworld_id: 588949571786
+  good: maybe
+  characters:

--- a/simpsons_data.json
+++ b/simpsons_data.json
@@ -4016,7 +4016,9 @@
             "disneyplus_id": null,
             "simpsonsworld_id": 256753731544,
             "good": false,
-            "characters": []
+            "characters": [
+                "marge"
+            ]
         },
         {
             "title": "Fat Man and Little Boy",
@@ -4040,7 +4042,10 @@
             "disneyplus_id": null,
             "simpsonsworld_id": 1094235715818,
             "good": false,
-            "characters": []
+            "characters": [
+                "homer",
+                "grandpa_simpson"
+            ]
         },
         {
             "title": "Mommie Beerest",
@@ -4050,7 +4055,11 @@
             "disneyplus_id": null,
             "simpsonsworld_id": 256807491582,
             "good": false,
-            "characters": []
+            "characters": [
+                "homer",
+                "marge",
+                "moe"
+            ]
         },
         {
             "title": "Homer and Ned's Hail Mary Pass",
@@ -4060,7 +4069,10 @@
             "disneyplus_id": null,
             "simpsonsworld_id": 256813635887,
             "good": false,
-            "characters": []
+            "characters": [
+                "homer",
+                "ned"
+            ]
         },
         {
             "title": "Pranksta Rap",
@@ -4070,7 +4082,10 @@
             "disneyplus_id": null,
             "simpsonsworld_id": 256798275935,
             "good": false,
-            "characters": []
+            "characters": [
+                "bart",
+                "wiggum"
+            ]
         },
         {
             "title": "There's Something About Marrying",
@@ -4080,7 +4095,11 @@
             "disneyplus_id": null,
             "simpsonsworld_id": 256822339660,
             "good": false,
-            "characters": []
+            "characters": [
+                "patty",
+                "homer",
+                "marge"
+            ]
         },
         {
             "title": "On a Clear Day I Can't See My Sister",
@@ -4090,7 +4109,11 @@
             "disneyplus_id": null,
             "simpsonsworld_id": 256825923849,
             "good": false,
-            "characters": []
+            "characters": [
+                "bart",
+                "lisa",
+                "homer"
+            ]
         },
         {
             "title": "Goo Goo Gai Pan",
@@ -4100,7 +4123,10 @@
             "disneyplus_id": null,
             "simpsonsworld_id": 264432707575,
             "good": false,
-            "characters": []
+            "characters": [
+                "simpsons",
+                "selma"
+            ]
         },
         {
             "title": "Mobile Homer",
@@ -4110,7 +4136,9 @@
             "disneyplus_id": null,
             "simpsonsworld_id": 264432707841,
             "good": false,
-            "characters": []
+            "characters": [
+                "simpsons"
+            ]
         },
         {
             "title": "The Seven-Beer Snitch",
@@ -4119,8 +4147,12 @@
             "description": "Homer becomes a prison snitch after he's convicted of breaking an outdated law; Lisa and Bart discover that Snowball II has a secret life.",
             "disneyplus_id": null,
             "simpsonsworld_id": 260844611804,
-            "good": false,
-            "characters": []
+            "good": true,
+            "characters": [
+                "homer",
+                "bart",
+                "lisa"
+            ]
         },
         {
             "title": "Future-Drama",
@@ -4130,7 +4162,9 @@
             "disneyplus_id": null,
             "simpsonsworld_id": 260841027999,
             "good": false,
-            "characters": []
+            "characters": [
+                "bart"
+            ]
         },
         {
             "title": "Don't Fear the Roofer",
@@ -4140,7 +4174,9 @@
             "disneyplus_id": null,
             "simpsonsworld_id": 260835395771,
             "good": false,
-            "characters": []
+            "characters": [
+                "homer"
+            ]
         },
         {
             "title": "The Heartbroke Kid",
@@ -4150,7 +4186,10 @@
             "disneyplus_id": null,
             "simpsonsworld_id": 264207427808,
             "good": false,
-            "characters": []
+            "characters": [
+                "bart",
+                "simpsons"
+            ]
         },
         {
             "title": "A Star is Torn",
@@ -5833,7 +5872,7 @@
             "season": 24,
             "episode": 1,
             "description": "Bart seeks out Cletus's daughter, who has started a new life in New York City, Lisa wants to take in a Broadway play but ends up performing Shakespeare in Central Park.",
-            "disneyplus_id": null,
+            "disneyplus_id": "15a66ce2-69d0-4f64-9d8b-dfd5d05111c0",
             "simpsonsworld_id": 221691971633,
             "good": false,
             "characters": []
@@ -5843,7 +5882,7 @@
             "season": 24,
             "episode": 2,
             "description": "In these three Halloween tales... a black hole threatens to destroy Springfield; the Simpsons are terrorized by the unknown in a spoof of 'Paranormal Activity'; Bart time travels in a spoof of 'Back to the Future.'",
-            "disneyplus_id": null,
+            "disneyplus_id": "1e683629-3099-4342-b9cd-830b67a607b2",
             "simpsonsworld_id": 221695555645,
             "good": true,
             "characters": [
@@ -5855,7 +5894,7 @@
             "season": 24,
             "episode": 3,
             "description": "Marge decides she wants to conceive another child; Bart realizes Lisa is up to something mysterious and vows to find out what it is.",
-            "disneyplus_id": null,
+            "disneyplus_id": "4e9dc8fc-19c1-493a-bcb5-d2cd463512ed",
             "simpsonsworld_id": 221688899646,
             "good": false,
             "characters": []
@@ -5865,7 +5904,7 @@
             "season": 24,
             "episode": 4,
             "description": "Homer and Marge search for Grampa after he disappears from the retirement home; Homer invests Lisa's college fund in an online poker Web site.",
-            "disneyplus_id": null,
+            "disneyplus_id": "95a59aa7-8dd8-4b37-946d-ba4b2370fe1b",
             "simpsonsworld_id": 221688899887,
             "good": false,
             "characters": []
@@ -5875,7 +5914,7 @@
             "season": 24,
             "episode": 5,
             "description": "While serving jury duty, Fat Tony appoints an accountant as his temporary Don; an anemic Lisa eats bugs to increase her iron level.",
-            "disneyplus_id": null,
+            "disneyplus_id": "2364e35d-b013-4ce2-8781-2528238ca84a",
             "simpsonsworld_id": 221694531617,
             "good": false,
             "characters": []
@@ -5885,7 +5924,7 @@
             "season": 24,
             "episode": 6,
             "description": "After his beloved new tablet \"MyPad\" computer is destroyed, a despondent Homer finds solace in a message seemingly written by God - until newsman Kent Brockman sets out to debunk the \"miracle.\"",
-            "disneyplus_id": null,
+            "disneyplus_id": "13091b84-3bf8-49b1-a289-1196270e20c5",
             "simpsonsworld_id": 229733443727,
             "good": false,
             "characters": []
@@ -5895,7 +5934,7 @@
             "season": 24,
             "episode": 7,
             "description": "Homer is elated when a cool dad and his family move next door, but his happiness ends when he realizes he has little in common with his new neighbors.",
-            "disneyplus_id": null,
+            "disneyplus_id": "9f181a16-923c-4b5f-b16c-6ed616dbd5bf",
             "simpsonsworld_id": 222374467937,
             "good": false,
             "characters": []
@@ -5905,7 +5944,7 @@
             "season": 24,
             "episode": 8,
             "description": "When Bart accuses Homer of not liking Santa's Little Helper, Grampa recounts the story of how Homer's heart broke after he was forced to give away his childhood dog.",
-            "disneyplus_id": null,
+            "disneyplus_id": "31835d74-90cf-407d-a5b4-5cfdf65364dd",
             "simpsonsworld_id": 222491715618,
             "good": false,
             "characters": []
@@ -5915,7 +5954,7 @@
             "season": 24,
             "episode": 9,
             "description": "The Simpsons anticipate the apocalypse after Homer inadvertently triggers a shockwave that disables all electronic devices in Springfield.",
-            "disneyplus_id": null,
+            "disneyplus_id": "e5ab93cc-8b25-4f41-ba33-618cd72303f1",
             "simpsonsworld_id": 1094312515873,
             "good": false,
             "characters": []
@@ -5925,7 +5964,7 @@
             "season": 24,
             "episode": 10,
             "description": "Bart must pass a district-wide test to save Springfield Elementary; Homer uses a discarded parking meter to steal from unsuspecting drivers.",
-            "disneyplus_id": null,
+            "disneyplus_id": "9d7c7493-3f24-4913-9982-af323ebc6a25",
             "simpsonsworld_id": 222388291945,
             "good": false,
             "characters": []
@@ -5935,7 +5974,7 @@
             "season": 24,
             "episode": 11,
             "description": "After narrowly surviving a tornado, Marge and Homer embark on a search for a couple who'll serve as Bart, Lisa and Maggie's legal guardians.",
-            "disneyplus_id": null,
+            "disneyplus_id": "b4979e57-2149-444f-a2ef-ffb99cad5fac",
             "simpsonsworld_id": 257684035668,
             "good": false,
             "characters": []
@@ -5945,7 +5984,7 @@
             "season": 24,
             "episode": 12,
             "description": "Bart attempts to patch things up with his old sweetheart, Mary Spuckler, and despite Lisa's input, still manages to sabotage his chances of finding love.",
-            "disneyplus_id": null,
+            "disneyplus_id": "680107c6-aa55-49d7-aad6-6e2260625b65",
             "simpsonsworld_id": 257681987573,
             "good": false,
             "characters": []
@@ -5955,7 +5994,7 @@
             "season": 24,
             "episode": 13,
             "description": "With Bart's help, Milhouse transforms into his father; Homer discovers a talent for finding things in hidden-picture books.",
-            "disneyplus_id": null,
+            "disneyplus_id": "9b94d4eb-f41a-4c7b-af02-75b13d18fa01",
             "simpsonsworld_id": 257686595928,
             "good": false,
             "characters": []
@@ -5965,7 +6004,7 @@
             "season": 24,
             "episode": 14,
             "description": "With encouragement from Mr. Burns, Grampa revives a famous wrestling character from his past whom audiences love to hate, and despite Homer and Marge's objections, incorporates Bart into the act.",
-            "disneyplus_id": null,
+            "disneyplus_id": "637c1f7b-b52b-4ac1-8a2b-781cc6254fdb",
             "simpsonsworld_id": 257687107857,
             "good": false,
             "characters": []
@@ -5975,7 +6014,7 @@
             "season": 24,
             "episode": 15,
             "description": "When Flanders gives Homer a black eye, he turns to the Bible for answers; Lisa is shocked and puzzled when she discovers that a substitute teacher hates her.",
-            "disneyplus_id": null,
+            "disneyplus_id": "50ca0957-7857-490c-8a02-91daa99ec26c",
             "simpsonsworld_id": 257689667578,
             "good": false,
             "characters": []
@@ -5985,7 +6024,7 @@
             "season": 24,
             "episode": 16,
             "description": "Bart stands trial in youth court after he's accused of pulling an Easter prank; after buying a comic book collection, Mr. Burns transforms into a 'Batman'-like superhero.",
-            "disneyplus_id": null,
+            "disneyplus_id": "56b4c00a-9a1d-4e34-95ee-fb57416428e7",
             "simpsonsworld_id": 257714243647,
             "good": false,
             "characters": []
@@ -5995,7 +6034,7 @@
             "season": 24,
             "episode": 17,
             "description": "In an episode that focuses on the choices people make and their outcomes... Homer attempts to save his marriage; Milhouse woos Lisa.",
-            "disneyplus_id": null,
+            "disneyplus_id": "6b63cb85-0417-4763-badc-cfe3abcafe10",
             "simpsonsworld_id": 1094243907551,
             "good": false,
             "characters": []
@@ -6005,7 +6044,7 @@
             "season": 24,
             "episode": 18,
             "description": "Lovejoy quits the church after the Parson appoints a charismatic reverend to reinvigorate the parish; Marge tracks down her old wedding dress.",
-            "disneyplus_id": null,
+            "disneyplus_id": "d7de92f2-f378-4328-86fd-1ba45b27e794",
             "simpsonsworld_id": 257728579751,
             "good": false,
             "characters": []
@@ -6015,7 +6054,7 @@
             "season": 24,
             "episode": 19,
             "description": "Moe's new suit catches the attention of venture capitalists, leading to the distribution of Moe's own brand of whiskey; Bart cares for Grampa; Lisa realizes that her favorite musicians have been turned into holograms.",
-            "disneyplus_id": null,
+            "disneyplus_id": "19842aab-5cbb-4b3f-a454-f519c3927f5e",
             "simpsonsworld_id": 257737283653,
             "good": false,
             "characters": []
@@ -6025,7 +6064,7 @@
             "season": 24,
             "episode": 20,
             "description": "Bart takes piano lessons in hopes of impressing his beautiful young teacher; Homer goes completely bald; Marge teaches a Russian man how to drive.",
-            "disneyplus_id": null,
+            "disneyplus_id": "44088609-5b17-4aa8-90f3-3ccbec6a5fdb",
             "simpsonsworld_id": 257760323921,
             "good": false,
             "characters": []
@@ -6035,7 +6074,7 @@
             "season": 24,
             "episode": 21,
             "description": "Homer, Moe and Lenny travel to Iceland to retrieve lottery winnings that Carl ran off with.",
-            "disneyplus_id": null,
+            "disneyplus_id": "407d6ec8-d258-4dc3-827c-a81cf50c8828",
             "simpsonsworld_id": 257753667515,
             "good": false,
             "characters": []
@@ -6045,7 +6084,7 @@
             "season": 24,
             "episode": 22,
             "description": "Homer secretly reconstructs a kiddy train as Marge's anniversary present; Marge attracts the attention of a potential paramour online.",
-            "disneyplus_id": null,
+            "disneyplus_id": "7220ab72-469d-4ce0-a41e-d727c10e72c4",
             "simpsonsworld_id": 257768003795,
             "good": false,
             "characters": []
@@ -6055,7 +6094,7 @@
             "season": 25,
             "episode": 1,
             "description": "When Homer returns from a Nuclear Workers Convention and begins behaving strangely, Lisa worries that her father has been brainwashed and is now part of a terrorist plot to blow up the power plant.",
-            "disneyplus_id": null,
+            "disneyplus_id": "52c632a3-fbc8-4d17-b46a-f5522ff30aaa",
             "simpsonsworld_id": 307191875741,
             "good": false,
             "characters": []
@@ -6065,7 +6104,7 @@
             "season": 25,
             "episode": 2,
             "description": "In three terrifying Halloween tales, Bart, Lisa and Maggie receive a visit from The Fat in the Hat; when Bart is decapitated, his head is sewn onto Lisa's body; Homer plots to kill Moe at a circus freak show.",
-            "disneyplus_id": null,
+            "disneyplus_id": "3ae51e62-c577-40cc-83fc-147cc4feccbf",
             "simpsonsworld_id": 310259779794,
             "good": false,
             "characters": [
@@ -6077,7 +6116,7 @@
             "season": 25,
             "episode": 3,
             "description": "A Springfield funeral prompts Marge, Kent Brockman, Homer and Mr. Burns to reexamine a crucial decision in their lives one that has brought them the most regret.",
-            "disneyplus_id": null,
+            "disneyplus_id": "166cebad-4ef0-404a-93ef-50166b7b847f",
             "simpsonsworld_id": 311688259548,
             "good": false,
             "characters": []
@@ -6087,7 +6126,7 @@
             "season": 25,
             "episode": 4,
             "description": "After experiencing a midlife crisis, Homer reaches out to an old pen pal; when a cheating scandal rocks Springfield Elementary, Lisa establishes an honor code.",
-            "disneyplus_id": null,
+            "disneyplus_id": "6b167486-d4b7-46c5-8246-2b24415d880a",
             "simpsonsworld_id": 304473155645,
             "good": false,
             "characters": []
@@ -6097,7 +6136,7 @@
             "season": 25,
             "episode": 5,
             "description": "Homer gets trapped in an elevator with a pregnant woman and helps deliver her baby; Lisa helps underpaid cheerleaders organize so they can demand a salary increase from a greedy football team owner.",
-            "disneyplus_id": null,
+            "disneyplus_id": "3ddd2387-3e2b-45d5-8003-075420c52ca9",
             "simpsonsworld_id": 311105091548,
             "good": false,
             "characters": []
@@ -6107,7 +6146,7 @@
             "season": 25,
             "episode": 6,
             "description": "Lisa is elated to befriend Isabel, a smart new student at school, only to realize that she and Isabel are on opposite sides of the political spectrum.",
-            "disneyplus_id": null,
+            "disneyplus_id": "4b47c46b-cbda-4ecd-8715-94935ca69273",
             "simpsonsworld_id": 310523971648,
             "good": false,
             "characters": []
@@ -6117,7 +6156,7 @@
             "season": 25,
             "episode": 7,
             "description": "Bart seeks revenge after Skinner prevents him from attending a school field trip aboard a submarine; Lisa suggests to the financially-strapped Krusty that he sell the foreign rights to his television show.",
-            "disneyplus_id": null,
+            "disneyplus_id": "febd486b-544e-4063-9f74-2925554c20a4",
             "simpsonsworld_id": 304476739664,
             "good": false,
             "characters": []
@@ -6127,7 +6166,7 @@
             "season": 25,
             "episode": 8,
             "description": "As Christmas approaches, Marge transforms the house into a bed and breakfast after Springfield becomes the only town in America to receive snowfall; Lisa vows to give her loved ones modest gifts that come from the heart.",
-            "disneyplus_id": null,
+            "disneyplus_id": "90d36b9f-c9da-4f5b-9c99-03f63a2742aa",
             "simpsonsworld_id": 307199043880,
             "good": false,
             "characters": []
@@ -6137,7 +6176,7 @@
             "season": 25,
             "episode": 9,
             "description": "Homer is put on trial after the FBI catches him illegally downloading movies from the Internet.",
-            "disneyplus_id": null,
+            "disneyplus_id": "0c9550cd-8044-4efe-8eed-aece092047f6",
             "simpsonsworld_id": 310523459925,
             "good": false,
             "characters": []
@@ -6147,7 +6186,7 @@
             "season": 25,
             "episode": 10,
             "description": "The Comic Book Guy marries a Japanese woman, only to discover that the woman's father disapproves of the union.",
-            "disneyplus_id": null,
+            "disneyplus_id": "c26f25f7-d8d3-4ea0-a62a-bcaaa8688b3f",
             "simpsonsworld_id": 310541379637,
             "good": false,
             "characters": []
@@ -6157,28 +6196,28 @@
             "season": 25,
             "episode": 11,
             "description": "Homer uses augmented reality glasses to spy on Marge; Nelson demands a Valentine's Day card from Bart.",
-            "disneyplus_id": null,
+            "disneyplus_id": "0c4e2f05-97c8-46fd-9699-6f44940717b7",
             "simpsonsworld_id": 307204163997,
-            "good": false,
-            "characters": []
-        },
-        {
-            "title": "Diggs",
-            "season": 25,
-            "episode": 12,
-            "description": "Bart befriends a fellow student and falconry expert, only to discover that the boy suffers from mental illness.",
-            "disneyplus_id": null,
-            "simpsonsworld_id": 310529091639,
             "good": false,
             "characters": []
         },
         {
             "title": "The Man Who Grew Too Much",
             "season": 25,
-            "episode": 13,
+            "episode": 12,
             "description": "Sideshow Bob genetically alters his DNA, giving him superhuman strength; Marge volunteers as a teen abstinence counselor.",
-            "disneyplus_id": null,
+            "disneyplus_id": "3afb3c6d-f176-4867-a1d1-c59758d9352b",
             "simpsonsworld_id": 307207235909,
+            "good": false,
+            "characters": []
+        },
+        {
+            "title": "Diggs",
+            "season": 25,
+            "episode": 13,
+            "description": "Bart befriends a fellow student and falconry expert, only to discover that the boy suffers from mental illness.",
+            "disneyplus_id": "9afafaa3-fa10-489b-9b30-8e95371eb8ac",
+            "simpsonsworld_id": 310529091639,
             "good": false,
             "characters": []
         },
@@ -6187,7 +6226,7 @@
             "season": 25,
             "episode": 14,
             "description": "When the Simpsons allow members of the retirement community to move in with them, Marge worries that Homer is picking up their habits and is turning into an old man; a gang of bullies accepts Bart as one of their own.",
-            "disneyplus_id": null,
+            "disneyplus_id": "bb32c897-8d50-495c-bce2-a9e91c4cc25b",
             "simpsonsworld_id": 307209283970,
             "good": false,
             "characters": []
@@ -6197,7 +6236,7 @@
             "season": 25,
             "episode": 15,
             "description": "Homer convinces Marge to sell a painting that was purchased from Milhouse's parents at a yard sale, a painting that turns out to be worth a great deal of money.",
-            "disneyplus_id": null,
+            "disneyplus_id": "d589791f-8d39-40bc-a438-ef791f0fe4a8",
             "simpsonsworld_id": 311117891947,
             "good": false,
             "characters": []
@@ -6207,7 +6246,7 @@
             "season": 25,
             "episode": 16,
             "description": "After Lisa delivers a school report on why her father is her hero, Homer is tapped to referee World Cup soccer in Brazil.",
-            "disneyplus_id": null,
+            "disneyplus_id": "7c3c7706-d070-4262-b4d6-21ce7e22899b",
             "simpsonsworld_id": 304489539783,
             "good": false,
             "characters": []
@@ -6217,7 +6256,7 @@
             "season": 25,
             "episode": 17,
             "description": "Lisa falls for a competitive eater who subconsciously reminds her of Homer; after Bart hides Jailbird from the police, he begins receiving stolen gifts.",
-            "disneyplus_id": null,
+            "disneyplus_id": "6d255409-bf57-40b6-bbc1-307bebde5538",
             "simpsonsworld_id": 304500803520,
             "good": false,
             "characters": []
@@ -6227,7 +6266,7 @@
             "season": 25,
             "episode": 18,
             "description": "Thirty years in the future, Bart tries to reestablish his relationship with his estranged wife, Jenda; Lisa thinks Milhouse is far more interesting after he's bitten by a zombie.",
-            "disneyplus_id": null,
+            "disneyplus_id": "9089df85-7fd5-4fad-9e1b-5f4e8c2a7822",
             "simpsonsworld_id": 310257731892,
             "good": false,
             "characters": []
@@ -6237,7 +6276,7 @@
             "season": 25,
             "episode": 19,
             "description": "Bart uses voodoo in an attempt to get rid of an art teacher, but when the teacher ends up getting pregnant, word spreads that Bart can help couples conceive.",
-            "disneyplus_id": null,
+            "disneyplus_id": "1042e57d-5c33-44a5-a3bf-03ed298ea748",
             "simpsonsworld_id": 307214403888,
             "good": false,
             "characters": []
@@ -6247,7 +6286,7 @@
             "season": 25,
             "episode": 20,
             "description": "After Homer bonds with Lisa, Homer's imagination creates a world in which everything is made of Lego toys.",
-            "disneyplus_id": null,
+            "disneyplus_id": "44ece42c-b05f-4368-91c4-ad72a5d23f61",
             "simpsonsworld_id": 311243331763,
             "good": false,
             "characters": []
@@ -6257,7 +6296,7 @@
             "season": 25,
             "episode": 21,
             "description": "As Mother's Day approaches, after Homer and Marge's attempt to befriend other couples fails miserably, Lisa discovers a shocking secret about her new best friend.",
-            "disneyplus_id": null,
+            "disneyplus_id": "c4b37972-da8c-4268-b348-668474719dc3",
             "simpsonsworld_id": 304502851923,
             "good": false,
             "characters": []
@@ -6267,7 +6306,7 @@
             "season": 25,
             "episode": 22,
             "description": "Bart is overcome with guilt after an act of cowardice leads to his winning a school race; Homer vows to hold his own Fourth of July fireworks display after Springfield's holiday celebration is canceled.",
-            "disneyplus_id": null,
+            "disneyplus_id": "ad75b189-ba84-41a8-af62-098025711897",
             "simpsonsworld_id": 307219523604,
             "good": false,
             "characters": []
@@ -6287,7 +6326,7 @@
             "season": 26,
             "episode": 1,
             "description": "The unthinkable happens: a Springfield resident dies.",
-            "disneyplus_id": null,
+            "disneyplus_id": "254b91ea-02ed-4b16-aa4e-03b594b89288",
             "simpsonsworld_id": 334920771636,
             "good": false,
             "characters": [
@@ -6299,7 +6338,7 @@
             "season": 26,
             "episode": 2,
             "description": "Homer and Bart set sail on the relation ship.",
-            "disneyplus_id": null,
+            "disneyplus_id": "6a793d21-929a-410a-8615-3f4444970e19",
             "simpsonsworld_id": 346737219924,
             "good": false,
             "characters": [
@@ -6312,7 +6351,7 @@
             "season": 26,
             "episode": 3,
             "description": "Marge opens a sandwich shop.",
-            "disneyplus_id": null,
+            "disneyplus_id": "c8a58eb9-dbab-471a-86b3-a04bc34c2cff",
             "simpsonsworld_id": 340536899599,
             "good": false,
             "characters": [
@@ -6324,7 +6363,7 @@
             "season": 26,
             "episode": 4,
             "description": "Don't miss the all-new, spooktacular Halloween special, \"Treehouse of Horror XXV.\"",
-            "disneyplus_id": null,
+            "disneyplus_id": "54d99d91-e952-4ff5-baf8-9eef1a054885",
             "simpsonsworld_id": 344255555880,
             "good": false,
             "characters": [
@@ -6336,7 +6375,7 @@
             "season": 26,
             "episode": 5,
             "description": "An all-new episode featuring guest voice Jane Fonda, whose character falls for Mr. Burns.",
-            "disneyplus_id": null,
+            "disneyplus_id": "0d02c072-ec15-4e51-b0eb-b0a8c683abd7",
             "simpsonsworld_id": 351437379941,
             "good": false,
             "characters": [
@@ -6349,7 +6388,7 @@
             "season": 26,
             "episode": 6,
             "description": "The Simpsons travel to the 31st century.",
-            "disneyplus_id": null,
+            "disneyplus_id": "4374e696-9cb9-4e95-b906-e623ad31593a",
             "simpsonsworld_id": 355593283530,
             "good": false,
             "characters": [
@@ -6361,7 +6400,7 @@
             "season": 26,
             "episode": 7,
             "description": "Bart faces a tough test at school when he gets a new teacher, Mr. Lassen, who vows to crush his spirit.",
-            "disneyplus_id": null,
+            "disneyplus_id": "34716532-5c16-4b0a-97fd-d71a2807f87a",
             "simpsonsworld_id": 359228483622,
             "good": false,
             "characters": [
@@ -6373,7 +6412,7 @@
             "season": 26,
             "episode": 8,
             "description": "Homer forms a cover band with some of the other dads in town.",
-            "disneyplus_id": null,
+            "disneyplus_id": "a1ed36d5-3086-49b8-b83e-2d20e72fa12b",
             "simpsonsworld_id": 362239555757,
             "good": false,
             "characters": [
@@ -6386,7 +6425,7 @@
             "season": 26,
             "episode": 9,
             "description": "Marge doesn't approve of Homer's Christmas spirits.",
-            "disneyplus_id": null,
+            "disneyplus_id": "16914d01-b98b-4cf2-8904-36bd8f651e8f",
             "simpsonsworld_id": 368212547872,
             "good": false,
             "characters": []
@@ -6396,7 +6435,7 @@
             "season": 26,
             "episode": 10,
             "description": "An amusement park ride lands the Simpsons in outer space..",
-            "disneyplus_id": null,
+            "disneyplus_id": "ea171ef8-0dab-48f9-bec1-491775080bc4",
             "simpsonsworld_id": 379818563729,
             "good": false,
             "characters": []
@@ -6406,7 +6445,7 @@
             "season": 26,
             "episode": 11,
             "description": "Bart and Homer become BFF's.",
-            "disneyplus_id": null,
+            "disneyplus_id": "b30df722-986c-46ba-8e51-be92095b6e17",
             "simpsonsworld_id": 383002179865,
             "good": false,
             "characters": []
@@ -6416,7 +6455,7 @@
             "season": 26,
             "episode": 12,
             "description": "Homer becomes muse to Elon Musk.",
-            "disneyplus_id": null,
+            "disneyplus_id": "2ee937da-4304-4ca5-868d-472e189d942d",
             "simpsonsworld_id": 388773443652,
             "good": false,
             "characters": []
@@ -6426,7 +6465,7 @@
             "season": 26,
             "episode": 13,
             "description": "Springfield gets a new town anthem.",
-            "disneyplus_id": null,
+            "disneyplus_id": "645c035f-4f8f-4422-884e-333889eae9f4",
             "simpsonsworld_id": 395694659511,
             "good": false,
             "characters": []
@@ -6436,7 +6475,7 @@
             "season": 26,
             "episode": 14,
             "description": "Marge trades in her mom-chauffeur hat for a real one.",
-            "disneyplus_id": null,
+            "disneyplus_id": "ff549ddd-2534-4769-9c8e-940e46363649",
             "simpsonsworld_id": 399385667625,
             "good": false,
             "characters": []
@@ -6446,7 +6485,7 @@
             "season": 26,
             "episode": 15,
             "description": "Moe plots revenge over Nigerian e-mail scam.",
-            "disneyplus_id": null,
+            "disneyplus_id": "77a22172-c5a9-4c80-b5ff-3d8fe21ecc3b",
             "simpsonsworld_id": 406163011894,
             "good": false,
             "characters": []
@@ -6456,7 +6495,7 @@
             "season": 26,
             "episode": 16,
             "description": "The Springfield congregation turns to gambling to repair the church.",
-            "disneyplus_id": null,
+            "disneyplus_id": "7571103b-40e7-4456-80b6-4d1856bc73b0",
             "simpsonsworld_id": 410018371522,
             "good": false,
             "characters": []
@@ -6466,7 +6505,7 @@
             "season": 26,
             "episode": 17,
             "description": "When Duffman undergoes hip replacement surgery and retires, the company sets up a reality show competition to find his replacement.",
-            "disneyplus_id": null,
+            "disneyplus_id": "8a3b1f5a-338d-4a7c-afcf-e3bb3933d0bb",
             "simpsonsworld_id": 420981315819,
             "good": false,
             "characters": []
@@ -6476,7 +6515,7 @@
             "season": 26,
             "episode": 18,
             "description": "Bart lies about being involved in a bulldozer crash, so Marge decides to follow him everywhere until he confesses.",
-            "disneyplus_id": null,
+            "disneyplus_id": "7570ff99-2fd0-47a3-b275-404c5b96cc10",
             "simpsonsworld_id": 430426691868,
             "good": false,
             "characters": []
@@ -6486,7 +6525,7 @@
             "season": 26,
             "episode": 19,
             "description": "When Homer gets an old film roll developed, the family takes a trip down memory lane to see the origins of how Bart and Lisa first started fighting with each other.",
-            "disneyplus_id": null,
+            "disneyplus_id": "240cf703-b203-40ce-83b3-150fa2bc7b06",
             "simpsonsworld_id": 434682947703,
             "good": false,
             "characters": []
@@ -6496,7 +6535,7 @@
             "season": 26,
             "episode": 20,
             "description": "The Simpsons learn about Grampa's days in the Air Force, and Bart takes up smoking to impress Milhouse's Dutch cousin.",
-            "disneyplus_id": null,
+            "disneyplus_id": "6398510e-4e51-4a48-a538-5781de70918b",
             "simpsonsworld_id": 438408259807,
             "good": false,
             "characters": [
@@ -6509,7 +6548,7 @@
             "season": 26,
             "episode": 21,
             "description": "After Bart gets bullied at the school dance, Marge convinces the town to pass anti-bullying legislation.",
-            "disneyplus_id": null,
+            "disneyplus_id": "677ab214-4cde-4a05-8767-369f7a59be8c",
             "simpsonsworld_id": 442879555692,
             "good": false,
             "characters": []
@@ -6519,7 +6558,7 @@
             "season": 26,
             "episode": 22,
             "description": "When a modernized Springfield Elementary has a technical meltdown, Lisa transforms it into a Waldorf school.",
-            "disneyplus_id": null,
+            "disneyplus_id": "ee46a17f-b96f-4db1-b8bf-0e25d09f9a59",
             "simpsonsworld_id": 446649411760,
             "good": false,
             "characters": []


### PR DESCRIPTION
Add D+ ids for seasons 24 to 26.

S25 includes a theatrical short that's out of the ordinal order; moving that to a theatrical section. I'll figure out what seasonto assign to that later.